### PR TITLE
fix: resolve audit findings M-8, M-13, M-18

### DIFF
--- a/contracts/flash-loan-v1.clar
+++ b/contracts/flash-loan-v1.clar
@@ -13,6 +13,7 @@
 (define-constant ERR_CONTRACT_NOT_ALLOWED (err u110000))
 (define-constant ERR-NOT-AUTHORIZED (err u110001))
 (define-constant ERR-INVALID-FEE (err u110002))
+(define-constant ERR-FLASH-LOAN-IN-PROGRESS (err u110003))
 
 
 ;; Data vars
@@ -22,6 +23,7 @@
 (define-data-var allow-any bool false)
 ;; Fee of 0.01% for processing flash loan scaled to 10^8
 (define-data-var fee uint u10000)
+(define-data-var flash-loan-in-progress bool false)
 
 ;; Read only functions
 
@@ -86,7 +88,9 @@
       (caller contract-caller)
       (callback-contract (contract-of callback))
     )
+    (asserts! (not (var-get flash-loan-in-progress)) ERR-FLASH-LOAN-IN-PROGRESS)
     (asserts! (is-contract-allowed callback-contract) ERR_CONTRACT_NOT_ALLOWED)
+    (var-set flash-loan-in-progress true)
     ;; transfer funds to user
     (try! (contract-call? .state-v1 transfer-to .mock-usdc caller amount))
     (try! (contract-call? callback on-granite-flash-loan amount flash-loan-fee data))
@@ -95,7 +99,8 @@
       (contract-call? .mock-usdc transfer flash-loan-fee caller (contract-call? .state-v1 get-governance) none)
       SUCCESS
     ))
-    
+    (var-set flash-loan-in-progress false)
+
     (print {
       action: "flash-loan",
       amount: amount,

--- a/contracts/governance-v1.clar
+++ b/contracts/governance-v1.clar
@@ -724,7 +724,8 @@
         expires-in: expires-in
       }) ERR-FAILED-TO-GENERATE-PROPOSAL-ID)))
     )
-    (asserts! (and (>= action ACTION_SET_DEPOSIT_ASSET_FLAG) (<= action ACTION_SET_INTEREST_ACCRUAL_FLAG)) ERR-INVALID-ACTION)
+    (asserts! (or (and (>= action ACTION_SET_DEPOSIT_ASSET_FLAG) (<= action ACTION_SET_LIQUIDATION_FLAG))
+                  (is-eq action ACTION_SET_INTEREST_ACCRUAL_FLAG)) ERR-INVALID-ACTION)
     (try! (create-proposal proposal-id action expires-in))
     (map-set set-market-feature-proposal-data proposal-id {
       flag: feature,
@@ -745,7 +746,7 @@
         expires-in: expires-in
       }) ERR-FAILED-TO-GENERATE-PROPOSAL-ID)))
     )
-    (asserts! (and (>= action ACTION_SET_MARKET_PAUSE_FLAG) (<= action ACTION_REMOVE_COLLATERAL)) ERR-INVALID-ACTION)
+    (asserts! (and (>= action ACTION_SET_MARKET_PAUSE_FLAG) (<= action ACTION_SET_MARKET_UNPAUSE_FLAG)) ERR-INVALID-ACTION)
     (map-set unpause-market-data proposal-id cooldown)
     (try! (create-proposal proposal-id action expires-in))
     ;; try to execute the proposal if threshold is met

--- a/contracts/liquidity-provider-v1.clar
+++ b/contracts/liquidity-provider-v1.clar
@@ -6,6 +6,7 @@
 
 ;; CONSTANTS
 (define-constant SUCCESS (ok true))
+(define-constant MINIMUM_INITIAL_DEPOSIT u1000) ;; 0.001 USDC (6 decimals) - enforced only on first deposit
 
 ;; PUBLIC FUNCTIONS
 (define-public (deposit (assets uint) (recipient principal))
@@ -16,7 +17,7 @@
         (total-assets (get total-assets lp-params))
         (shares (contract-call? .math-v1 convert-to-shares lp-params assets false))
       )
-      (try! (if (and (is-eq total-assets u0) (is-eq assets u1)) ERR-ASSET-TOO-LOW SUCCESS))
+      (try! (if (and (is-eq total-assets u0) (< assets MINIMUM_INITIAL_DEPOSIT)) ERR-ASSET-TOO-LOW SUCCESS))
       (try! (contract-call? .withdrawal-caps-v1 lp-deposit assets))
       (try! (contract-call? .state-v1 add-assets contract-caller recipient assets shares))
       (print { 

--- a/tests/borrower.test.ts
+++ b/tests/borrower.test.ts
@@ -819,11 +819,11 @@ describe("borrower tests", () => {
       deployer
     );
     mint_token("mock-btc", 2e8, borrower1);
-    mint_token("mock-usdc", 100000002, borrower1);
+    mint_token("mock-usdc", 100001000, borrower1);
     mint_token("mock-usdc", 1800000e8, borrower2);
 
-    // 1. attacker deposit 2
-    deposit(2, borrower1);
+    // 1. attacker deposit 1000 (minimum initial deposit enforced by M-8 fix)
+    deposit(1000, borrower1);
 
     let userBalancePostBorrow = simnet.callReadOnlyFn(
       "mock-usdc",
@@ -868,7 +868,7 @@ describe("borrower tests", () => {
     expect(borrow.result).toBeErr(Cl.uint(20001));
 
     // 5. victim deposit many usdc to protocol, and receive the same amount of share token balance
-    deposit(9999999999998, borrower2);
+    deposit(9999999999000, borrower2);
 
     let shareTokenBalance = simnet.callReadOnlyFn(
       "state-v1",
@@ -876,7 +876,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower2)],
       borrower2
     );
-    expect(shareTokenBalance.result.value.value).toEqual(9999999999998n);
+    expect(shareTokenBalance.result.value.value).toEqual(9999999999000n);
 
     shareTokenBalance = simnet.callReadOnlyFn(
       "state-v1",
@@ -884,7 +884,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower2
     );
-    expect(shareTokenBalance.result.value.value).toEqual(2n);
+    expect(shareTokenBalance.result.value.value).toEqual(1000n);
 
     // 6. attacker redeem but cannot steal from protocol
     const response = simnet.callPublicFn(
@@ -1090,7 +1090,37 @@ describe("borrower tests", () => {
     remove_collateral("mock-btc", 549948753641, deployer, borrower1);
   });
 
-  it.each([2, 10, 25, 50, 75, 100, 500, 1000, 2500, 7500, 10000, 22500, 72500])(
+  it("should reject initial deposit below minimum", async () => {
+    mint_token("mock-usdc", 100_000_000_000, borrower1);
+    // Deposit of 2 (far below minimum) should fail
+    let depositResult = simnet.callPublicFn(
+      "liquidity-provider-v1",
+      "deposit",
+      [Cl.uint(2), Cl.principal(borrower1)],
+      borrower1
+    );
+    expect(depositResult.result).toBeErr(Cl.uint(10001)); // ERR-ASSET-TOO-LOW
+
+    // Deposit of 999 (one below boundary) should also fail
+    depositResult = simnet.callPublicFn(
+      "liquidity-provider-v1",
+      "deposit",
+      [Cl.uint(999), Cl.principal(borrower1)],
+      borrower1
+    );
+    expect(depositResult.result).toBeErr(Cl.uint(10001)); // ERR-ASSET-TOO-LOW
+
+    // Deposit of exactly 1000 (the minimum) should succeed
+    depositResult = simnet.callPublicFn(
+      "liquidity-provider-v1",
+      "deposit",
+      [Cl.uint(1000), Cl.principal(borrower1)],
+      borrower1
+    );
+    expect(depositResult.result).toBeOk(Cl.bool(true));
+  });
+
+  it.each([1000, 2500, 7500, 10000, 22500, 72500])(
     "should not have vault inflation attack: %i",
     async (initial_deposit) => {
       mint_token("mock-usdc", 100_000_000_000, borrower1);

--- a/tests/flash-loan.test.ts
+++ b/tests/flash-loan.test.ts
@@ -240,4 +240,8 @@ describe("Flash loan tests", () => {
 
     expectUserUSDCBalance(Cl.principal(user1), BigInt(0));
   });
+
+  // Note: Direct reentrancy of flash-loan is prevented by Clarity's VM-level circular reference
+  // protection. The flash-loan-in-progress guard (M-13) serves as defense-in-depth and primarily
+  // prevents protocol operations from reading inconsistent state during the callback window.
 });

--- a/tests/governance.test.ts
+++ b/tests/governance.test.ts
@@ -223,10 +223,12 @@ describe("governance tests", () => {
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
 
+    // Use amount >= MINIMUM_INITIAL_DEPOSIT (u1000) to bypass M-8 guard and test the deposit-disabled flag
+    mint_token("mock-usdc", 1000, governance_account);
     response = simnet.callPublicFn(
       "liquidity-provider-v1",
       "deposit",
-      [Cl.uint(0), Cl.principal(governance_account)],
+      [Cl.uint(1000), Cl.principal(governance_account)],
       governance_account
     );
     expect(response.result).toBeErr(Cl.uint(102));
@@ -289,6 +291,59 @@ describe("governance tests", () => {
       deployer
     );
     expect(response.result).toStrictEqual(Cl.bool(false));
+  });
+
+  it("should reject out-of-range actions for market feature proposals (M-18)", async () => {
+    state_set_governance_contract(deployer);
+
+    // Action u9 (market pause) is no longer valid for set-market-feature
+    let response = simnet.callPublicFn(
+      "governance-v1",
+      "initiate-proposal-to-set-market-feature",
+      [Cl.uint(9), Cl.bool(false), Cl.uint(10), Cl.uint(0)],
+      governance_account
+    );
+    expect(response.result).toBeErr(Cl.uint(40000)); // ERR-INVALID-ACTION
+
+    // Action u22 (remove collateral) is no longer valid for set-market-feature
+    response = simnet.callPublicFn(
+      "governance-v1",
+      "initiate-proposal-to-set-market-feature",
+      [Cl.uint(22), Cl.bool(false), Cl.uint(10), Cl.uint(0)],
+      governance_account
+    );
+    expect(response.result).toBeErr(Cl.uint(40000)); // ERR-INVALID-ACTION
+
+    // Action u8 (liquidation flag, upper bound) should still be accepted
+    response = simnet.callPublicFn(
+      "governance-v1",
+      "initiate-proposal-to-set-market-feature",
+      [Cl.uint(8), Cl.bool(true), Cl.uint(10), Cl.uint(0)],
+      governance_account
+    );
+    expect(response.result.type).toBe(ClarityType.ResponseOk);
+  });
+
+  it("should reject out-of-range actions for market state proposals (M-18)", async () => {
+    state_set_governance_contract(deployer);
+
+    // Action u11 (collateral settings) is no longer valid for set-market-state
+    let response = simnet.callPublicFn(
+      "governance-v1",
+      "initiate-proposal-to-set-market-state",
+      [Cl.uint(11), Cl.uint(10), Cl.uint(0)],
+      governance_account
+    );
+    expect(response.result).toBeErr(Cl.uint(40000)); // ERR-INVALID-ACTION
+
+    // Action u10 (market unpause, upper bound) should still be accepted
+    response = simnet.callPublicFn(
+      "governance-v1",
+      "initiate-proposal-to-set-market-state",
+      [Cl.uint(10), Cl.uint(10), Cl.uint(0)],
+      governance_account
+    );
+    expect(response.result.type).toBe(ClarityType.ResponseOk);
   });
 
   it("should be able to disable liquidations until a given block", async () => {

--- a/tests/liquidity_provider.test.ts
+++ b/tests/liquidity_provider.test.ts
@@ -34,7 +34,7 @@ describe("liquidity-provider tests", () => {
       [Cl.uint(0), Cl.principal(depositor1)],
       depositor1
     );
-    expect(deposit.result).toBeErr(Cl.uint(101));
+    expect(deposit.result).toBeErr(Cl.uint(10001)); // ERR-ASSET-TOO-LOW (M-8 minimum deposit guard)
 
     // Attempt to withdraw 0 assets
     const withdraw = simnet.callPublicFn(
@@ -72,7 +72,7 @@ describe("liquidity-provider tests", () => {
     simnet.callPublicFn(
       "mock-usdc",
       "mint",
-      [Cl.uint(1000), Cl.principal(depositor1)],
+      [Cl.uint(2000), Cl.principal(depositor1)],
       depositor1
     );
 
@@ -80,7 +80,7 @@ describe("liquidity-provider tests", () => {
     const depositResult = simnet.callPublicFn(
       "liquidity-provider-v1",
       "deposit",
-      [Cl.uint(100), Cl.principal(depositor1)],
+      [Cl.uint(1000), Cl.principal(depositor1)],
       depositor1
     );
     expect(depositResult.result).toBeOk(Cl.bool(true));
@@ -92,22 +92,21 @@ describe("liquidity-provider tests", () => {
       [Cl.principal(depositor1)],
       depositor1
     );
-    // User should have 98 assets after deposit
-    expect(userBalancePostDeposit.result.value.value).toBe(900n);
+    expect(userBalancePostDeposit.result.value.value).toBe(1000n);
     const userLpBalancePostDeposit = simnet.callReadOnlyFn(
       "state-v1",
       "get-balance",
       [Cl.principal(depositor1)],
       depositor1
     );
-    // User should have 100 LP tokens after deposit
-    expect(userLpBalancePostDeposit.result.value.value).toBe(100n);
+    // User should have 1000 LP tokens after deposit
+    expect(userLpBalancePostDeposit.result.value.value).toBe(1000n);
 
     /* Withdrawal flow */
     const withdrawalResult = simnet.callPublicFn(
       "liquidity-provider-v1",
       "withdraw",
-      [Cl.uint(100), Cl.principal(depositor1)],
+      [Cl.uint(1000), Cl.principal(depositor1)],
       depositor1
     );
     expect(withdrawalResult.result).toBeOk(Cl.bool(true));
@@ -119,8 +118,7 @@ describe("liquidity-provider tests", () => {
       [Cl.principal(depositor1)],
       depositor1
     );
-    // User should have 99 assets after withdrawal
-    expect(userBalancePostWithdrawal.result.value.value).toBe(1000n);
+    expect(userBalancePostWithdrawal.result.value.value).toBe(2000n);
     const userLpBalancePostWithdrawal = simnet.callReadOnlyFn(
       "state-v1",
       "get-balance",
@@ -132,23 +130,23 @@ describe("liquidity-provider tests", () => {
   });
 
   it("should correctly handle deposits and withdrawals with multiple users", async () => {
-    // Mint asset tokens for all depositors
+    // Mint asset tokens for all depositors (scaled up to meet M-8 minimum initial deposit)
     simnet.callPublicFn(
       "mock-usdc",
       "mint",
-      [Cl.uint(50), Cl.principal(depositor1)],
+      [Cl.uint(1000), Cl.principal(depositor1)],
       depositor1
     );
     simnet.callPublicFn(
       "mock-usdc",
       "mint",
-      [Cl.uint(100), Cl.principal(depositor2)],
+      [Cl.uint(2000), Cl.principal(depositor2)],
       depositor2
     );
     simnet.callPublicFn(
       "mock-usdc",
       "mint",
-      [Cl.uint(150), Cl.principal(depositor3)],
+      [Cl.uint(3000), Cl.principal(depositor3)],
       depositor3
     );
 
@@ -156,24 +154,24 @@ describe("liquidity-provider tests", () => {
     simnet.callPublicFn(
       "liquidity-provider-v1",
       "deposit",
-      [Cl.uint(50), Cl.principal(depositor1)],
+      [Cl.uint(1000), Cl.principal(depositor1)],
       depositor1
     );
     simnet.callPublicFn(
       "liquidity-provider-v1",
       "deposit",
-      [Cl.uint(100), Cl.principal(depositor2)],
+      [Cl.uint(2000), Cl.principal(depositor2)],
       depositor2
     );
     simnet.callPublicFn(
       "liquidity-provider-v1",
       "deposit",
-      [Cl.uint(150), Cl.principal(depositor3)],
+      [Cl.uint(3000), Cl.principal(depositor3)],
       depositor3
     );
 
     // Gift assets
-    const interestAmount = Cl.uint(100);
+    const interestAmount = Cl.uint(2000);
     simnet.callPublicFn(
       "mock-usdc",
       "mint",
@@ -218,65 +216,65 @@ describe("liquidity-provider tests", () => {
       [Cl.principal(depositor1)],
       depositor1
     );
-    expect(lpBalanceAfterDeposit.result.value.value).toBe(50n);
+    expect(lpBalanceAfterDeposit.result.value.value).toBe(1000n);
     lpBalanceAfterDeposit = simnet.callReadOnlyFn(
       "state-v1",
       "get-balance",
       [Cl.principal(depositor2)],
       depositor2
     );
-    expect(lpBalanceAfterDeposit.result.value.value).toBe(100n);
+    expect(lpBalanceAfterDeposit.result.value.value).toBe(2000n);
     lpBalanceAfterDeposit = simnet.callReadOnlyFn(
       "state-v1",
       "get-balance",
       [Cl.principal(depositor3)],
       depositor3
     );
-    expect(lpBalanceAfterDeposit.result.value.value).toBe(150n);
+    expect(lpBalanceAfterDeposit.result.value.value).toBe(3000n);
 
     let redeemResult = simnet.callPublicFn(
       "liquidity-provider-v1",
       "redeem",
-      [Cl.uint(50), Cl.principal(depositor1)],
+      [Cl.uint(1000), Cl.principal(depositor1)],
       depositor1
     );
     expect(redeemResult.result).toBeOk(Cl.bool(true));
     redeemResult = simnet.callPublicFn(
       "liquidity-provider-v1",
       "redeem",
-      [Cl.uint(100), Cl.principal(depositor2)],
+      [Cl.uint(2000), Cl.principal(depositor2)],
       depositor2
     );
     expect(redeemResult.result).toBeOk(Cl.bool(true));
     redeemResult = simnet.callPublicFn(
       "liquidity-provider-v1",
       "redeem",
-      [Cl.uint(150), Cl.principal(depositor3)],
+      [Cl.uint(3000), Cl.principal(depositor3)],
       depositor3
     );
     expect(redeemResult.result).toBeOk(Cl.bool(true));
 
-    // Check redeeming shares brings profits to LPs
+    // Check redeeming shares brings profits to LPs (scaled 20x from original)
     let assetBalanceAfterWithdrawal = simnet.callReadOnlyFn(
       "mock-usdc",
       "get-balance",
       [Cl.principal(depositor1)],
       depositor1
     );
-    expect(assetBalanceAfterWithdrawal.result.value.value).toBe(66n);
+    expect(assetBalanceAfterWithdrawal.result.value.value).toBe(1333n);
     assetBalanceAfterWithdrawal = simnet.callReadOnlyFn(
       "mock-usdc",
       "get-balance",
       [Cl.principal(depositor2)],
       depositor2
     );
-    expect(assetBalanceAfterWithdrawal.result.value.value).toBe(133n);
+    expect(assetBalanceAfterWithdrawal.result.value.value).toBe(2666n);
     assetBalanceAfterWithdrawal = simnet.callReadOnlyFn(
       "mock-usdc",
       "get-balance",
       [Cl.principal(depositor3)],
       depositor3
     );
-    expect(assetBalanceAfterWithdrawal.result.value.value).toBe(201n);
+    expect(assetBalanceAfterWithdrawal.result.value.value).toBe(4001n);
   });
 });


### PR DESCRIPTION
## Summary

Continues V1.5 audit remediation (follows PRs #47–#50). Fixes 3 MEDIUM findings from the 2026-03-10 Claude Code Security Audit V2.

- **M-18**: Tighten governance action validation ranges — `initiate-proposal-to-set-market-feature` narrowed from u2–u23 to u2–u8 + u23, `initiate-proposal-to-set-market-state` narrowed from u9–u22 to u9–u10. Prevents creating proposals with mismatched action types that `unwrap-panic` on execution.
- **M-8**: Enforce minimum initial deposit (u1000 / 0.001 USDC) when LP pool is empty. Mitigates first-depositor share inflation attack (previously only blocked deposits of exactly 1).
- **M-13**: Add flash loan reentrancy guard via boolean flag covering the entire operation (checks-effects-interactions pattern). Defense-in-depth — Clarity VM also prevents circular references at runtime.

No `state-v1` modifications. All 207 tests pass.

## Test plan

- [x] `clarinet check` — 36 contracts compile
- [x] `npm test` — 207/207 tests pass
- [x] M-18: Boundary tests for reject (u9, u11, u22) and accept (u8, u10) action values
- [x] M-8: Boundary tests at 2 (reject), 999 (reject), 1000 (accept)
- [x] M-13: Existing flash loan tests pass with guard in place; Clarity VM circular reference protection documented
- [x] No state-v1 changes (verified via `git diff`)