### PR TITLE
fix(M-01): proportional staked-part split prevents no-stakers DoS

### DIFF
--- a/contracts/borrower-v1.clar
+++ b/contracts/borrower-v1.clar
@@ -97,10 +97,6 @@
         (lp-open-interest-without-principal (contract-call? .math-v1 safe-sub (get lp-open-interest interest-params) total-borrowed-amount))
         (lp-part (contract-call? .math-v1 safe-div (* interest-part lp-open-interest-without-principal) open-interest-without-principal))
         (protocol-part (contract-call? .math-v1 safe-div (* interest-part (get protocol-open-interest interest-params)) open-interest-without-principal))
-        ;; M-01: proportional split (was remainder; pre-fix underflowed when
-        ;; no LP tokens were staked). Up to ~2 dust units / tx are left
-        ;; unassigned to any open-interest bucket and stay parked in
-        ;; state-v1's free-liquidity -- accepted trade-off vs. the DoS.
         (staked-part (contract-call? .math-v1 safe-div (* interest-part (get staked-open-interest interest-params)) open-interest-without-principal))
         (asset-params (contract-call? .state-v1 get-lp-params))
         (staked-lp-tokens (contract-call? .math-v1 convert-to-shares asset-params staked-part false))

--- a/contracts/borrower-v1.clar
+++ b/contracts/borrower-v1.clar
@@ -97,7 +97,11 @@
         (lp-open-interest-without-principal (contract-call? .math-v1 safe-sub (get lp-open-interest interest-params) total-borrowed-amount))
         (lp-part (contract-call? .math-v1 safe-div (* interest-part lp-open-interest-without-principal) open-interest-without-principal))
         (protocol-part (contract-call? .math-v1 safe-div (* interest-part (get protocol-open-interest interest-params)) open-interest-without-principal))
-        (staked-part (contract-call? .math-v1 safe-sub interest-part (+ lp-part protocol-part)))
+        ;; M-01: proportional split (was remainder; pre-fix underflowed when
+        ;; no LP tokens were staked). Up to ~2 dust units / tx are left
+        ;; unassigned to any open-interest bucket and stay parked in
+        ;; state-v1's free-liquidity -- accepted trade-off vs. the DoS.
+        (staked-part (contract-call? .math-v1 safe-div (* interest-part (get staked-open-interest interest-params)) open-interest-without-principal))
         (asset-params (contract-call? .state-v1 get-lp-params))
         (staked-lp-tokens (contract-call? .math-v1 convert-to-shares asset-params staked-part false))
         (total-user-debt-shares (unwrap! (contract-call? .math-v1 sub (get debt-shares position) shares) ERR-NOT-ENOUGH-SHARES))

--- a/contracts/liquidator-v1.clar
+++ b/contracts/liquidator-v1.clar
@@ -287,7 +287,8 @@
         ;; calculate liquidity provider and protocol debt repaid
         (lp-part (contract-call? .math-v1 safe-div (* interest-part lp-open-interest-without-principal) open-interest-without-principal))
         (protocol-part (contract-call? .math-v1 safe-div (* interest-part (get protocol-open-interest open-interest-info)) open-interest-without-principal))
-        (staked-part (contract-call? .math-v1 safe-sub interest-part (+ lp-part protocol-part)))
+        ;; M-01: proportional split (see borrower-v1 for rationale).
+        (staked-part (contract-call? .math-v1 safe-div (* interest-part (get staked-open-interest open-interest-info)) open-interest-without-principal))
         (asset-params (contract-call? .state-v1 get-lp-params))
         (staked-lp-tokens (contract-call? .math-v1 convert-to-shares asset-params staked-part false))
         (updated-borrowed-amount (contract-call? .math-v1 safe-sub user-borrowed-amount principal-part))
@@ -540,7 +541,8 @@
             (lp-open-interest-without-principal (contract-call? .math-v1 safe-sub lp-open-interest-val total-borrowed-amount))
             (lp-interest-part (contract-call? .math-v1 safe-div (* interest-part lp-open-interest-without-principal) open-interest-without-principal))
             (protocol-part (contract-call? .math-v1 safe-div (* interest-part protocol-open-interest-val) open-interest-without-principal))
-            (staked-part (contract-call? .math-v1 safe-sub interest-part (+ lp-interest-part protocol-part)))
+            ;; M-01: proportional split (see borrower-v1 for rationale).
+            (staked-part (contract-call? .math-v1 safe-div (* interest-part staked-open-interest-val) open-interest-without-principal))
             (lp-part (+ principal-part lp-interest-part))
             (updated-total-borrowed-amount (contract-call? .math-v1 safe-sub total-borrowed-amount principal-part))
             (staked-lp-tokens (contract-call? .staking-v1 get-total-staked-lp-tokens))

--- a/contracts/liquidator-v1.clar
+++ b/contracts/liquidator-v1.clar
@@ -287,7 +287,6 @@
         ;; calculate liquidity provider and protocol debt repaid
         (lp-part (contract-call? .math-v1 safe-div (* interest-part lp-open-interest-without-principal) open-interest-without-principal))
         (protocol-part (contract-call? .math-v1 safe-div (* interest-part (get protocol-open-interest open-interest-info)) open-interest-without-principal))
-        ;; M-01: proportional split (see borrower-v1 for rationale).
         (staked-part (contract-call? .math-v1 safe-div (* interest-part (get staked-open-interest open-interest-info)) open-interest-without-principal))
         (asset-params (contract-call? .state-v1 get-lp-params))
         (staked-lp-tokens (contract-call? .math-v1 convert-to-shares asset-params staked-part false))
@@ -541,7 +540,6 @@
             (lp-open-interest-without-principal (contract-call? .math-v1 safe-sub lp-open-interest-val total-borrowed-amount))
             (lp-interest-part (contract-call? .math-v1 safe-div (* interest-part lp-open-interest-without-principal) open-interest-without-principal))
             (protocol-part (contract-call? .math-v1 safe-div (* interest-part protocol-open-interest-val) open-interest-without-principal))
-            ;; M-01: proportional split (see borrower-v1 for rationale).
             (staked-part (contract-call? .math-v1 safe-div (* interest-part staked-open-interest-val) open-interest-without-principal))
             (lp-part (+ principal-part lp-interest-part))
             (updated-total-borrowed-amount (contract-call? .math-v1 safe-sub total-borrowed-amount principal-part))

--- a/tests/borrower.test.ts
+++ b/tests/borrower.test.ts
@@ -1234,3 +1234,219 @@ describe("borrower tests", () => {
     }
   );
 });
+
+// M-01: when no LP tokens are staked, state-v1's staked-open-interest stays at
+// zero forever. Pre-fix, the upgradable callers computed staked-part as a
+// remainder (interest-part - lp-part - protocol-part) which produced a non-zero
+// dust value from flooring whenever lp/protocol shares didn't divide evenly.
+// state-v1 then ran a raw subtraction (- 0 dust) on the zero baseline,
+// underflowing and reverting the entire repay/liquidate transaction.
+//
+// Post-fix, staked-part is computed proportionally via safe-div, which returns
+// 0 cleanly when staked-open-interest = 0. The trade-off is up to ~2 dust
+// units of interest per tx going unassigned to any bucket — economically
+// negligible, dramatically preferable to a DoS on every repay/liquidate.
+describe("M-01 interest-dust no-stakers regression", () => {
+  beforeEach(async () => {
+    init_pyth(deployer);
+    set_pyth_time_delta(7200, deployer);
+    set_allowed_contracts(deployer);
+    set_asset_cap(deployer, 10000000000000n);
+    initialize_ir(deployer);
+    initialize_staking_reward(deployer);
+    await set_initial_price("mock-usdc", 1n, deployer);
+    await set_initial_price("mock-btc", 1n, deployer);
+  });
+
+  it("borrower-v1::update-repay-state path: repay succeeds with no stakers across a sweep of repay amounts", async () => {
+    // Pool + borrower setup. Nobody stakes — staked-open-interest stays 0.
+    // The bug surfaces when (lp-share, protocol-share) of interest-part
+    // produce a flooring residue that the upgradable callers route to
+    // staked-part. Whether the residue is 0 or 1 depends sensitively on
+    // the repay amount, so we sweep a range to ensure we hit residue cases.
+    mint_token("mock-usdc", 100_000_000_000, depositor);
+    deposit(100_000_000_000, depositor);
+
+    update_supported_collateral(
+      "mock-btc",
+      70000000,
+      80000000,
+      10000000,
+      8,
+      deployer
+    );
+    mint_token("mock-btc", 100_000_000_000, borrower1);
+    add_collateral("mock-btc", 80_000_000_000, deployer, borrower1);
+    // Push utilization high so the kinked IR drives substantial interest.
+    borrow(50_000_000_000, borrower1);
+
+    // Heavy time elapsed → meaningful interest accrual that produces awkward
+    // ratios when split across (lp, protocol).
+    simnet.mineEmptyBlocks(50_000);
+
+    // Sanity: confirm there are no stakers. get-total-staked-lp-tokens
+    // returns a bare uint (not a response), so we read .value directly.
+    const totalStaked = simnet.callReadOnlyFn(
+      "staking-v1",
+      "get-total-staked-lp-tokens",
+      [],
+      deployer
+    );
+    expect(totalStaked.result.value).toBe(0n);
+
+    mint_token("mock-usdc", 200_000_000_000, borrower1);
+
+    // Sweep a range of awkward partial-repay amounts that produce flooring
+    // residues across the (lp-part, protocol-part) split. With protocol-
+    // reserve-percentage > 0 set in beforeEach, every one of these triggers
+    // the pre-fix underflow inside state-v1::update-repay-state because the
+    // residue routes a non-zero staked-part into the (- 0 residue) path.
+    // Post-fix safe-div returns 0 cleanly for every amount.
+    for (const amount of [
+      1_000_000_001, 2_500_000_003, 3_333_333_337, 7_777_777_777,
+    ]) {
+      const res = simnet.callPublicFn(
+        "borrower-v1",
+        "repay",
+        [Cl.uint(amount), Cl.none()],
+        borrower1
+      );
+      expect(res.result).toBeOk(Cl.bool(true));
+    }
+  });
+
+  it("liquidator-v1::update-liquidate-collateral-state path: liquidation succeeds with no stakers", async () => {
+    mint_token("mock-usdc", 100_000_000_000, depositor);
+    deposit(100_000_000_000, depositor);
+
+    // Generous initial LTV so the borrow lands.
+    update_supported_collateral(
+      "mock-btc",
+      90000000,
+      95000000,
+      5000000,
+      8,
+      deployer
+    );
+    mint_token("mock-btc", 100_000_000_000, borrower1);
+    add_collateral("mock-btc", 20_000_000_000, deployer, borrower1);
+    borrow(18_000_000_000, borrower1);
+
+    // Mine plenty of blocks so interest accrual produces flooring residues
+    // across the lp / protocol split (the M-01 trigger condition).
+    simnet.mineEmptyBlocks(500);
+
+    // Refresh prices (pyth staleness window is shorter than the mined gap).
+    await set_price("mock-usdc", 1n, deployer);
+    await set_price("mock-btc", 1n, deployer);
+
+    // Tighten LTV to push the position underwater.
+    update_supported_collateral(
+      "mock-btc",
+      40000000,
+      50000000,
+      2000000,
+      8,
+      deployer
+    );
+
+    // Sanity: confirm there are no stakers. get-total-staked-lp-tokens
+    // returns a bare uint (not a response), so we read .value directly.
+    const totalStaked = simnet.callReadOnlyFn(
+      "staking-v1",
+      "get-total-staked-lp-tokens",
+      [],
+      deployer
+    );
+    expect(totalStaked.result.value).toBe(0n);
+
+    mint_token("mock-usdc", 18_181_818_181, depositor);
+    simnet.mineEmptyBlocks(6); // liquidation cooldown
+    const res = simnet.callPublicFn(
+      "liquidator-v1",
+      "liquidate-collateral",
+      [
+        Cl.none(),
+        btc_collateral_contract,
+        Cl.principal(borrower1),
+        Cl.uint(18_181_818_181),
+        Cl.uint(1),
+      ],
+      depositor
+    );
+    // Pre-fix this would underflow inside state-v1::update-liquidate-collateral-state.
+    expect(res.result).toBeOk(Cl.bool(true));
+  });
+
+  it("liquidator-v1::socialize-user-bad-debt path: bad-debt socialization succeeds with no stakers", async () => {
+    mint_token("mock-usdc", 100_000_000_000, depositor);
+    deposit(100_000_000_000, depositor);
+
+    update_supported_collateral(
+      "mock-btc",
+      90000000,
+      95000000,
+      5000000,
+      8,
+      deployer
+    );
+    mint_token("mock-btc", 100_000_000_000, borrower1);
+    add_collateral("mock-btc", 20_000_000_000, deployer, borrower1);
+    borrow(18_000_000_000, borrower1);
+
+    simnet.mineEmptyBlocks(500);
+
+    // Refresh prices (pyth staleness window is shorter than the mined gap).
+    await set_price("mock-usdc", 1n, deployer);
+    await set_price("mock-btc", 1n, deployer);
+
+    // Sanity: confirm there are no stakers. get-total-staked-lp-tokens
+    // returns a bare uint (not a response), so we read .value directly.
+    const totalStaked = simnet.callReadOnlyFn(
+      "staking-v1",
+      "get-total-staked-lp-tokens",
+      [],
+      deployer
+    );
+    expect(totalStaked.result.value).toBe(0n);
+
+    // High liquidation discount + tighter LTV pushes the seize-all path
+    // beyond the borrower's collateral value, leaving residual debt that
+    // gets socialized via state-v1::socialize-user-bad-debt.
+    update_supported_collateral(
+      "mock-btc",
+      40000000,
+      50000000,
+      20000000,
+      8,
+      deployer
+    );
+
+    mint_token("mock-usdc", 18_181_818_181, depositor);
+    simnet.mineEmptyBlocks(6);
+    const res = simnet.callPublicFn(
+      "liquidator-v1",
+      "liquidate-collateral",
+      [
+        Cl.none(),
+        btc_collateral_contract,
+        Cl.principal(borrower1),
+        Cl.uint(18_181_818_181),
+        Cl.uint(1),
+      ],
+      depositor
+    );
+    expect(res.result).toBeOk(Cl.bool(true));
+
+    // Verify the bad-debt path was actually entered. socialize-bad-debt is a
+    // private helper with two short-circuit gates — without this assertion
+    // a "healthy partial-liquidation" outcome would pass the test and leave
+    // the M-01 site uncovered.
+    const socializedEvent = res.events.find(
+      (e: any) =>
+        e.event === "print_event" &&
+        e.data?.value?.data?.action?.data === "socialized-bad-debt"
+    );
+    expect(socializedEvent).toBeDefined();
+  });
+});


### PR DESCRIPTION
When a market has zero LP tokens staked, state-v1's `staked-open-interest` stays at u0 forever — accrue-interest never adds to it because `staking-reward-percentage = 0`. The upgradable callers were computing `staked-part` as a remainder (`safe-sub interest-part (+ lp-part protocol-part)`) which produced a non-zero dust value from flooring whenever the lp/protocol shares didn't divide `interest-part` evenly. state-v1 then ran a raw subtraction `(- u0 dust)` at the staked-open-interest update site, underflowing and reverting the whole transaction → DoS on every repay and liquidate when no one stakes, which is the default state for any new market.

Three call sites all in upgradable contracts — `borrower-v1::repay`, `liquidator-v1::execute-liquidation`, `liquidator-v1::socialize-bad-debt` — switched to compute staked-part proportionally via `safe-div` on `(get staked-open-interest <record>)`. When staked-open-interest is u0 the multiplication is u0 and safe-div returns u0 cleanly. Trade-off accepted by the auditor: up to ~2 dust units of interest per tx end up unassigned to any open-interest bucket and stay parked in state-v1's free-liquidity. Negligible vs. the DoS.

Tests are scoped to the no-stakers configuration AND set `protocol-reserve-percentage = 10%` so accrual produces a non-zero protocol bucket (otherwise lp-part = interest-part exactly and no flooring residue can land in staked-part — pre-fix is unreachable). With that precondition all three new tests fail pre-fix with ArithmeticUnderflow at the corresponding state-v1 raw-sub site and pass post-fix:

- `borrower-v1::update-repay-state` exercised via a sweep of awkward partial-repay amounts.
- `liquidator-v1::update-liquidate-collateral-state` exercised via LTV tightening to push the position underwater.
- `liquidator-v1::socialize-user-bad-debt` exercised via high liquidation discount + tighter LTV; assertion verifies the `socialized-bad-debt` print event was actually emitted, since that path has two short-circuit gates that would otherwise let a healthy partial-liquidation path silently pass the test.