### PR TITLE
chore(LEV-M-01): TODO marker in state-v1 for v2 phantom-collateral fix

### DIFF
--- a/contracts/state-v1.clar
+++ b/contracts/state-v1.clar
@@ -827,8 +827,20 @@
     ;; reduce position collateral amount
     (map-set user-collaterals {user: user, collateral: collateral-token} {amount: (- user-balance collateral-to-give)})
     ;; reduce position debt shares and total debt shares
+    ;; TODO:(ved) LEV-M-01 -- this writes back the stale collaterals list
+    ;; from `position` instead of the `updated-collaterals` field passed in
+    ;; via `liquidate-collateral-state`. On a full collateral seizure that
+    ;; leaves a zero-balance phantom entry in the position, wasting one of
+    ;; the 10 collateral slots and potentially bricking the position if
+    ;; governance later removes the token's oracle feed. Fix is one line:
+    ;; `collaterals: (get updated-collaterals liquidate-collateral-state),`
+    ;; but state-v1 is immutable in production; deferred to v2 / contract
+    ;; migration. Auditor note (ABA, 2026-05-08): "issue is already known
+    ;; (reported in previous reports), I only noted here down to remind you
+    ;; of it and because of the potential DoS on position, if the oracle
+    ;; feed is removed."
     (map-set positions user {
-      debt-shares: (- (get debt-shares position) paid-shares), 
+      debt-shares: (- (get debt-shares position) paid-shares),
       collaterals: (get collaterals position),
       borrowed-amount: (get borrowed-amount liquidate-collateral-state),
       borrowed-block: (get borrowed-block position)


### PR DESCRIPTION
LEV-M-01 from the Cybasecurity / Magnus audit (Other Findings — will not appear in the public report per ABA's note). The `update-liquidate-collateral-state` function declares an `updated-collaterals` parameter but its body writes back `(get collaterals position)` (the stale pre-liquidation list). On a full collateral seizure, the user position retains a zero-balance phantom entry, wastes one of the 10 collateral slots, and can permanently brick the position if governance later removes that token's oracle feed.

The fix is one line — route the `updated-collaterals` parameter through to the `map-set positions` call — but `state-v1` is immutable in production. Deferring to v2 / contract migration; this PR adds the TODO marker so the v2 work picks it up automatically. Tracked in project memory alongside the other migration follow-ups. No behavioural change; tests stay at 207/207.

Notion finding marked Acknowledged.