### PR TITLE
fix(M-03): close staking wipe-out family — wipe detection + post-wipe LP token leak

### DIFF
--- a/contracts/borrower-v1.clar
+++ b/contracts/borrower-v1.clar
@@ -98,6 +98,8 @@
         (staked-part (contract-call? .math-v1 safe-div (* interest-part (get staked-open-interest interest-params)) open-interest-without-principal))
         (asset-params (contract-call? .state-v1 get-lp-params))
         (staked-lp-tokens (contract-call? .math-v1 convert-to-shares asset-params staked-part false))
+        (is-wiped (contract-call? .staking-v1 is-staking-wiped-out))
+        (effective-staked-lp-tokens (if is-wiped u0 staked-lp-tokens))
         (total-user-debt-shares (unwrap! (contract-call? .math-v1 sub (get debt-shares position) shares) ERR-NOT-ENOUGH-SHARES))
         (updated-borrowed-amount (contract-call? .math-v1 safe-sub effective-borrowed-amount principal-part))
         (updated-total-borrowed-amount (contract-call? .math-v1 safe-sub total-borrowed-amount
@@ -114,14 +116,14 @@
         lp-part: (+ principal-part lp-part),
         protocol-part: protocol-part,
         staked-part: staked-part,
-        staked-lp-tokens: staked-lp-tokens,
+        staked-lp-tokens: effective-staked-lp-tokens,
         payor: contract-caller,
         borrowed-amount: updated-borrowed-amount,
         total-borrowed-amount: updated-total-borrowed-amount,
         staking-contract: .staking-v1,
         borrowed-block: (get borrowed-block position)
       }))
-      (try! (contract-call? .staking-v1 increase-lp-staked-balance staked-lp-tokens))
+      (try! (contract-call? .staking-v1 increase-lp-staked-balance effective-staked-lp-tokens))
       (print {
         assets: repay-amount,
         total-user-debt-shares: total-user-debt-shares,

--- a/contracts/liquidator-v1.clar
+++ b/contracts/liquidator-v1.clar
@@ -289,6 +289,8 @@
         (staked-part (contract-call? .math-v1 safe-div (* interest-part (get staked-open-interest open-interest-info)) open-interest-without-principal))
         (asset-params (contract-call? .state-v1 get-lp-params))
         (staked-lp-tokens (contract-call? .math-v1 convert-to-shares asset-params staked-part false))
+        (is-wiped (contract-call? .staking-v1 is-staking-wiped-out))
+        (effective-staked-lp-tokens (if is-wiped u0 staked-lp-tokens))
         (remaining-user-debt-shares (contract-call? .math-v1 safe-sub (get debt-shares position-for-block-check) paid-shares))
         (updated-borrowed-amount (contract-call? .math-v1 safe-sub effective-borrowed-amount principal-part))
         (updated-total-borrowed-amount (contract-call? .math-v1 safe-sub total-borrowed-amount
@@ -312,14 +314,14 @@
         lp-part: (+ principal-part lp-part),
         protocol-part: protocol-part,
         staked-part: staked-part,
-        staked-lp-tokens: staked-lp-tokens,
+        staked-lp-tokens: effective-staked-lp-tokens,
         borrowed-amount: updated-borrowed-amount,
         total-borrowed-amount: updated-total-borrowed-amount,
         staking-contract: .staking-v1,
         remaining-balance: remaining-collateral-balance,
         updated-collaterals: updated-collaterals-list
       }))
-      (try! (contract-call? .staking-v1 increase-lp-staked-balance staked-lp-tokens))
+      (try! (contract-call? .staking-v1 increase-lp-staked-balance effective-staked-lp-tokens))
       (try! (contract-call? .withdrawal-caps-v1 repay repay-amount))
       ;; slippage check
       (asserts! (>= collateral-to-give min-collateral-expected) ERR-SLIPPAGE)
@@ -543,7 +545,9 @@
             (lp-part (+ principal-part lp-interest-part))
             (updated-total-borrowed-amount (contract-call? .math-v1 safe-sub total-borrowed-amount user-borrowed-amount))
             (staked-lp-tokens (contract-call? .staking-v1 get-total-staked-lp-tokens))
-            (burned-staking-lp-tokens (try! (contract-call? .state-v1 socialize-user-bad-debt user remaining-debt lp-part staked-part protocol-part updated-total-borrowed-amount .staking-v1 staked-lp-tokens)))
+            (is-wiped (contract-call? .staking-v1 is-staking-wiped-out))
+            (effective-staked-lp-tokens (if is-wiped u0 staked-lp-tokens))
+            (burned-staking-lp-tokens (try! (contract-call? .state-v1 socialize-user-bad-debt user remaining-debt lp-part staked-part protocol-part updated-total-borrowed-amount .staking-v1 effective-staked-lp-tokens)))
           )
           (print {
             user: user,

--- a/contracts/staking-v1.clar
+++ b/contracts/staking-v1.clar
@@ -189,54 +189,63 @@
 (define-public (increase-lp-staked-balance (lp-tokens uint))
   (begin
     (try! (contract-call? .state-v1 is-allowed-contract contract-caller))
-    (var-set total-lp-tokens-staked (+ (var-get total-lp-tokens-staked) lp-tokens))
-    (print {
-      action: "increase-lp-staked-balance",
-      amount: lp-tokens,
-    })
-    SUCCESS
+    (if (var-get staking-wiped-out)
+      (begin
+        (print {
+          action: "increase-lp-staked-balance-skipped-wiped",
+          amount: lp-tokens,
+        })
+        SUCCESS
+      )
+      (begin
+        (var-set total-lp-tokens-staked (+ (var-get total-lp-tokens-staked) lp-tokens))
+        (print {
+          action: "increase-lp-staked-balance",
+          amount: lp-tokens,
+        })
+        SUCCESS
+      )
+    )
   )
 )
 
 
 (define-public (slash-total-staked-lp-tokens (lp-tokens uint))
-  (let (
-      (total-staked-lp-tokens (get-total-staked-lp-tokens))
-      (unfinalized-withdrawal-info (var-get unfinalized-withdrawals))
-      (withdrawal-lp-tokens (get lp-tokens unfinalized-withdrawal-info))
-      (withdrawal-lp-tokens-to-slash (/ (* lp-tokens withdrawal-lp-tokens) total-staked-lp-tokens))
-      (active-staked-lp-tokens-to-slash (- lp-tokens withdrawal-lp-tokens-to-slash))
-    ) 
+  (begin
     (try! (contract-call? .state-v1 is-allowed-contract contract-caller))
-    (var-set total-lp-tokens-staked (- (var-get total-lp-tokens-staked) active-staked-lp-tokens-to-slash))
-    (if (is-eq withdrawal-lp-tokens withdrawal-lp-tokens-to-slash)
-      (var-set unfinalized-withdrawals {
-        lp-tokens: u0,
-        shares: u0,
-      })
-      (var-set unfinalized-withdrawals {
-        lp-tokens: (- withdrawal-lp-tokens withdrawal-lp-tokens-to-slash),
-        shares: (get shares unfinalized-withdrawal-info),
-      })
+    (if (or (is-eq lp-tokens u0) (is-eq (get-total-staked-lp-tokens) u0))
+      SUCCESS
+      (let (
+          (total-staked-lp-tokens (get-total-staked-lp-tokens))
+          (unfinalized-withdrawal-info (var-get unfinalized-withdrawals))
+          (withdrawal-lp-tokens (get lp-tokens unfinalized-withdrawal-info))
+          (withdrawal-lp-tokens-to-slash (/ (* lp-tokens withdrawal-lp-tokens) total-staked-lp-tokens))
+          (active-staked-lp-tokens-to-slash (- lp-tokens withdrawal-lp-tokens-to-slash))
+          (new-active (- (var-get total-lp-tokens-staked) active-staked-lp-tokens-to-slash))
+        )
+        (var-set total-lp-tokens-staked new-active)
+        (if (is-eq withdrawal-lp-tokens withdrawal-lp-tokens-to-slash)
+          (var-set unfinalized-withdrawals { lp-tokens: u0, shares: u0 })
+          (var-set unfinalized-withdrawals {
+            lp-tokens: (- withdrawal-lp-tokens withdrawal-lp-tokens-to-slash),
+            shares: (get shares unfinalized-withdrawal-info),
+          })
+        )
+        (if (is-eq new-active u0)
+          (begin
+            (var-set staking-wiped-out true)
+            (print { action: "staking-wipe-out", amount: lp-tokens })
+            SUCCESS
+          )
+          (begin
+            (print { action: "slash-total-staked-lp-tokens", amount: lp-tokens })
+            SUCCESS
+          )
+        )
+      )
     )
-    (if (is-eq lp-tokens total-staked-lp-tokens)
-      (begin 
-        (var-set staking-wiped-out true)
-        (print {
-          action: "staking-wipe-out",
-          amount: lp-tokens,
-        })
-        SUCCESS
-      )
-
-      (begin 
-        (print {
-          action: "slash-total-staked-lp-tokens",
-          amount: lp-tokens,
-        })
-        SUCCESS  
-      )
-)))
+  )
+)
 
 (define-public (reconcile-lp-token-balance)
   (let (

--- a/contracts/staking-v1.clar
+++ b/contracts/staking-v1.clar
@@ -324,7 +324,10 @@
         lp-tokens: (- (get lp-tokens unfinalized-withdrawal-info) lp-tokens-to-return),
         shares: (- (get shares unfinalized-withdrawal-info) withdraw-shares),
       })
-      true
+      (var-set unfinalized-withdrawals {
+        lp-tokens: (contract-call? .math-v1 safe-sub (get lp-tokens unfinalized-withdrawal-info) lp-tokens-to-return),
+        shares: (contract-call? .math-v1 safe-sub (get shares unfinalized-withdrawal-info) withdraw-shares),
+      })
     )
     (map-delete user-withdrawals {user: user, index: index})
      (print {


### PR DESCRIPTION
Two coupled bugs in the staking wipe-out flow, recombined as M-03 in the audit. Supersedes the earlier LEV-H-01 / PR #57 approach (which absorbed `staked-part` into `lp-part` on wipe — that absorption inflated the LP deduction past `lp-open-interest`'s actual balance, and `state-v1::update-repay-state` uses raw subtraction on each open-interest bucket, so every post-wipe repay/liquidation underflowed and reverted).

**Bug A — wipe-out detection gap.** `staking-v1::slash-total-staked-lp-tokens` triggered the `staking-wiped-out` flag via `(is-eq lp-tokens total-staked-lp-tokens)`. The slash splits across active and withdrawal-queue buckets using floor division on the queue side. When the queue is small relative to total, `withdrawal-lp-tokens-to-slash` rounds to zero and the entire slash hits active. If `lp-tokens` is close to but below `total`, active reaches zero while the queue retains dust — the equality check fails even though active is exhausted, so the flag never fires and zombie stakers can extract phantom rewards.

**Bug B — post-wipe LP token leak.** Even after the flag correctly fires, `borrower-v1::repay`, `liquidator-v1::execute-liquidation`, and `liquidator-v1::socialize-bad-debt` don't gate on it. Every repay or liquidation passes a non-zero `staked-lp-tokens` through `state-v1::update-repay-state` (which `ft-mint?`s into the dead staking contract) and `staking-v1::increase-lp-staked-balance` (which bumps the active counter). Self-reinforcing because the next accrual sees a non-zero staked balance and re-attributes interest to staking.

**Fix** (per ABA's M-03 recommendation):

- `slash-total-staked-lp-tokens`: detect wipe-out on the post-slash active counter, not on `lp-tokens == total`. Add `(is-eq new-active u0)` check after applying the slash. Add an early-return for zero inputs (defense against division-by-zero when called with totals of zero).
- `increase-lp-staked-balance`: silent no-op when wiped, defense-in-depth against any caller that misses the gate.
- `borrower-v1::repay`, `liquidator-v1::execute-liquidation`: when wiped, zero only the `staked-lp-tokens` passed to `update-repay-state` and `increase-lp-staked-balance`. Keep `staked-part` unchanged so `state-v1`'s per-bucket accounting reduces `staked-open-interest` proportionally and drains the residual cleanly (no underflow).
- `liquidator-v1::socialize-bad-debt`: same pattern on the `staked-lp-tokens` input to `state-v1::socialize-user-bad-debt`. `staked-part` stays unchanged for bucket reduction.

224/224 vitest green.