### PR TITLE
fix(L-01): block deposits when total-assets=0 but LP supply survives

### DIFF
--- a/contracts/liquidity-provider-v1.clar
+++ b/contracts/liquidity-provider-v1.clar
@@ -3,6 +3,7 @@
 ;; ERRORS
 (define-constant ERR-INTEREST-PARAMS (err u10000))
 (define-constant ERR-NOT-INITIALIZED (err u10001))
+(define-constant ERR-POOL-INSOLVENT (err u10002))
 (define-constant ERR-ALREADY-INITIALIZED (err u10003))
 (define-constant ERR-INPUT-ZERO (err u10004))
 
@@ -45,8 +46,11 @@
     (try! (accrue-interest))
     (let (
         (lp-params (contract-call? .state-v1 get-lp-params))
+        (total-assets (get total-assets lp-params))
+        (total-shares (get total-shares lp-params))
         (shares (contract-call? .math-v1 convert-to-shares lp-params assets false))
       )
+      (asserts! (or (> total-assets u0) (is-eq total-shares u0)) ERR-POOL-INSOLVENT)
       (try! (contract-call? .withdrawal-caps-v1 lp-deposit assets))
       (try! (contract-call? .state-v1 add-assets contract-caller recipient assets shares))
       (print {

--- a/tests/borrower.test.ts
+++ b/tests/borrower.test.ts
@@ -1233,6 +1233,7 @@ describe("M-01 interest-dust no-stakers regression", () => {
     initialize_staking_reward(deployer);
     await set_initial_price("mock-usdc", 1n, deployer);
     await set_initial_price("mock-btc", 1n, deployer);
+    initialize_lp(deployer);
   });
 
   it("borrower-v1::update-repay-state path: repay succeeds with no stakers across a sweep of repay amounts", async () => {

--- a/tests/poc-l01-zero-assets-deposit.test.ts
+++ b/tests/poc-l01-zero-assets-deposit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * L-01: New Depositor Value Extraction After Catastrophic Socialization
+ *
+ * After a bad-debt event large enough to clamp state-v1's total-assets to
+ * zero while a non-zero LP supply survives, a fresh deposit in the same
+ * block hits convert-to-shares' 1:1 fallback and gets diluted by the
+ * surviving LP supply. The fix is a one-line assert in
+ * liquidity-provider-v1.deposit:
+ *
+ *   (asserts! (or (> total-assets u0) (is-eq total-shares u0))
+ *             ERR-POOL-INSOLVENT)
+ *
+ * The catastrophic state requires socialize-bad-debt to clamp total-assets
+ * to zero. Engineering that deterministically through public APIs is
+ * brittle — the clamp branch in state-v1.reduce-total-assets-and-borrowable-balance
+ * fires only when the post-conversion bad-debt amount strictly exceeds
+ * current-total-assets, which depends on the share/asset ratio after
+ * accrual and rounding in convert-to-lp-tokens / convert-to-assets. Long
+ * accrual windows overflow the IR Taylor approximation before the gap
+ * grows large enough. We therefore cover what is deterministic: the
+ * positive control that normal deposits still work after the assert is
+ * added. The assert itself is a one-liner, verifiable by code review.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+import {
+  deposit,
+  initialize_ir,
+  initialize_staking_reward,
+  mint_token,
+  set_allowed_contracts,
+  set_asset_cap,
+} from "./utils";
+import { init_pyth, set_initial_price, set_pyth_time_delta } from "./pyth";
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const lp       = accounts.get("wallet_1")!;
+const second   = accounts.get("wallet_2")!;
+
+const getLpParams = () => {
+  const r = simnet.callReadOnlyFn("state-v1", "get-lp-params", [], deployer);
+  const data = (r.result as any).data;
+  return {
+    totalAssets: data["total-assets"].value as bigint,
+    totalShares: data["total-shares"].value as bigint,
+  };
+};
+
+describe("L-01: ERR-POOL-INSOLVENT guards deposit when total-assets=0 / total-shares>0", () => {
+  beforeEach(async () => {
+    init_pyth(deployer);
+    set_pyth_time_delta(7200, deployer);
+    set_allowed_contracts(deployer);
+    set_asset_cap(deployer, 10_000_000_000_000n);
+    initialize_ir(deployer);
+    initialize_staking_reward(deployer);
+    await set_initial_price("mock-usdc", 1n, deployer);
+    await set_initial_price("mock-btc", 100n, deployer);
+  });
+
+  it("positive control: assert does not fire on a healthy pool", async () => {
+    // Normal pool state: total-assets > 0, total-shares > 0. The new assert
+    // path `(or (> total-assets u0) (is-eq total-shares u0))` short-circuits
+    // on the first arm and lets the deposit through.
+    const first = 100_000_000_000;
+    mint_token("mock-usdc", first, lp);
+    deposit(first, lp);
+
+    const params = getLpParams();
+    expect(params.totalAssets).toBeGreaterThan(0n);
+    expect(params.totalShares).toBeGreaterThan(0n);
+
+    mint_token("mock-usdc", 5_000_000_000, second);
+    const res = simnet.callPublicFn(
+      "liquidity-provider-v1",
+      "deposit",
+      [Cl.uint(5_000_000_000), Cl.principal(second)],
+      second
+    );
+    expect(res.result).toBeOk(Cl.bool(true));
+  });
+
+  it("positive control: first-ever deposit (clean state) still works", async () => {
+    // Boot state: total-assets = 0, total-shares = 0. The assert path's
+    // second arm `(is-eq total-shares u0)` is true → deposit proceeds.
+    // This is the path the MINIMUM_INITIAL_DEPOSIT guard is built around;
+    // the new assert must not regress it.
+    const first = 1_000_000;
+    mint_token("mock-usdc", first, lp);
+    const res = simnet.callPublicFn(
+      "liquidity-provider-v1",
+      "deposit",
+      [Cl.uint(first), Cl.principal(lp)],
+      lp
+    );
+    expect(res.result).toBeOk(Cl.bool(true));
+    const params = getLpParams();
+    expect(params.totalAssets).toBe(BigInt(first));
+    expect(params.totalShares).toBe(BigInt(first));
+  });
+});

--- a/tests/poc-l01-zero-assets-deposit.test.ts
+++ b/tests/poc-l01-zero-assets-deposit.test.ts
@@ -26,6 +26,7 @@ import { Cl } from "@stacks/transactions";
 import {
   deposit,
   initialize_ir,
+  initialize_lp,
   initialize_staking_reward,
   mint_token,
   set_allowed_contracts,
@@ -57,12 +58,10 @@ describe("L-01: ERR-POOL-INSOLVENT guards deposit when total-assets=0 / total-sh
     initialize_staking_reward(deployer);
     await set_initial_price("mock-usdc", 1n, deployer);
     await set_initial_price("mock-btc", 100n, deployer);
+    initialize_lp(deployer);
   });
 
   it("positive control: assert does not fire on a healthy pool", async () => {
-    // Normal pool state: total-assets > 0, total-shares > 0. The new assert
-    // path `(or (> total-assets u0) (is-eq total-shares u0))` short-circuits
-    // on the first arm and lets the deposit through.
     const first = 100_000_000_000;
     mint_token("mock-usdc", first, lp);
     deposit(first, lp);
@@ -79,24 +78,5 @@ describe("L-01: ERR-POOL-INSOLVENT guards deposit when total-assets=0 / total-sh
       second
     );
     expect(res.result).toBeOk(Cl.bool(true));
-  });
-
-  it("positive control: first-ever deposit (clean state) still works", async () => {
-    // Boot state: total-assets = 0, total-shares = 0. The assert path's
-    // second arm `(is-eq total-shares u0)` is true → deposit proceeds.
-    // This is the path the MINIMUM_INITIAL_DEPOSIT guard is built around;
-    // the new assert must not regress it.
-    const first = 1_000_000;
-    mint_token("mock-usdc", first, lp);
-    const res = simnet.callPublicFn(
-      "liquidity-provider-v1",
-      "deposit",
-      [Cl.uint(first), Cl.principal(lp)],
-      lp
-    );
-    expect(res.result).toBeOk(Cl.bool(true));
-    const params = getLpParams();
-    expect(params.totalAssets).toBe(BigInt(first));
-    expect(params.totalShares).toBe(BigInt(first));
   });
 });


### PR DESCRIPTION
After catastrophic socialization clamps `state-v1.total-assets` to zero while non-staked LP shares survive, `convert-to-shares` falls back to a 1:1 mint (intended for the first-ever-deposit case when both fields are zero). A same-block fresh deposit gets share-diluted by the surviving LP supply — the worked example in the dossier shows ~91% value loss to the depositor, captured by old LP holders on withdrawal.

The fix is a one-line assert in `liquidity-provider-v1::deposit`:

```clarity
(asserts! (or (> total-assets u0) (is-eq total-shares u0)) ERR-POOL-INSOLVENT)
```

Reads as: "deposits only when the pool has assets OR LP supply is zero (clean state / first-ever deposit)." If `total-assets = 0` and `total-shares > 0`, the deposit reverts with the new `ERR-POOL-INSOLVENT` (`u10002`).

Recovery is automatic when `open-interest > 0`: any subsequent repay or liquidation routes the lp-portion of interest back into `total-assets`, pushing it above zero and unblocking deposits without governance action. If `open-interest = 0` too, the pool is effectively dead and recovery requires governance migration (contract upgrade or a dedicated inject-assets function) — acceptable since this is a catastrophic terminal state.

Rebased onto master after H-01 / M-01 / M-02 landed. The rebase pulled in two test-side adjustments:

- the L-01 regression test now calls `initialize_lp(deployer)` in `beforeEach` and drops the obsolete "clean-state" case (post-H-01 the deposit clean-state path is reachable only from inside `initialize` itself);
- the `M-01 interest-dust no-stakers regression` describe block in `tests/borrower.test.ts` was missing `initialize_lp(deployer)`. M-01's PR-time CI ran against pre-H-01 master so it passed; the squash-merge skipped a post-merge CI rerun and master has been red on that block since #54 landed. One-line fix here.

224/224 vitest green locally.