### PR TITLE
fix: resolve audit findings I-04, I-05, I-06, I-07

### DIFF
--- a/contracts/lp-incentives-v2.clar
+++ b/contracts/lp-incentives-v2.clar
@@ -51,7 +51,6 @@
 (define-constant ERR-USER-REWARDS-CLAIMED (err u100009))
 (define-constant ERR-REWARDS-NOT-CLAIMED (err u100010))
 (define-constant ERR-INVALID-SNAPSHOT-TIME (err u100011))
-(define-constant ERR-NOT-AUTHORIZED (err u100012))
 
 ;; Read-only functions
 (define-read-only (get-epoch-details)
@@ -122,7 +121,6 @@
 (define-public (claim-rewards (on-behalf-of (optional principal)))
   (let (
       (user (default-to contract-caller on-behalf-of))
-      (auth-check (asserts! (or (is-eq contract-caller user) (is-none on-behalf-of)) ERR-NOT-AUTHORIZED))
       (rewards (unwrap! (map-get? user-rewards user) ERR-NO-USER-REWARDS))
       (reward-amount (get earned-rewards rewards))
     )

--- a/contracts/modules/linear-kinked-ir-utility.clar
+++ b/contracts/modules/linear-kinked-ir-utility.clar
@@ -11,9 +11,11 @@
 (define-constant fact_5 u120000000000000)
 (define-constant fact_6 u720000000000000)
 (define-constant seconds-in-year u31536000)
+;; Matches MAX-UTILIZATION in linear-kinked-ir-v1.clar -- keep in sync.
+(define-constant MAX-UTILIZATION u10000000000000)
 
 
-;; READ-ONLY FUNCTIONS 
+;; READ-ONLY FUNCTIONS
 
 ;; Accrues interest based on the the last accrued block
 ;; returns updated lp interest, staked interest, protocol interest, total assets, and last accrued block
@@ -67,7 +69,10 @@
 ;; PRIVATE HELPER FUNCTIONS 
 ;; total-assets and open-interest are fixed to u8 precision
 (define-private (utilization-calc (total-assets uint) (open-interest uint))
-  (if (> total-assets u0) (/ (* open-interest one-12) total-assets) u0)
+  (if (> total-assets u0)
+    (let ((u (/ (* open-interest one-12) total-assets)))
+      (if (<= u MAX-UTILIZATION) u MAX-UTILIZATION))
+    u0)
 )
 
 (define-private (get-ir (total-assets uint) (open-interest uint) (ir-slope-1 uint) (ir-slope-2 uint) (utilization-kink uint) (base-ir uint))

--- a/contracts/modules/linear-kinked-ir-v1.clar
+++ b/contracts/modules/linear-kinked-ir-v1.clar
@@ -24,6 +24,10 @@
 (define-constant seconds-in-year u31536000)
 (define-constant MAX-IR-PARAM u100000000000000)
 (define-constant MAX-TAYLOR-INPUT u2000000000000)
+;; 10x (1000%) in 12-fixed. Caps effective interest-rate output so the
+;; Taylor input guard at MAX-TAYLOR-INPUT cannot brick accrue-interest
+;; under stressed (open-interest > total-assets) conditions.
+(define-constant MAX-UTILIZATION u10000000000000)
 (define-constant STACKS_BLOCK_TIME (contract-call? .constants-v1 get-stacks-block-time ))
 
 ;; DATA-VARS 
@@ -121,7 +125,10 @@
 
 ;; total-assets and open-interest are fixed to u8 precision
 (define-read-only (utilization-calc (total-assets uint) (open-interest uint))
-  (if (> total-assets u0) (/ (* open-interest one-12) total-assets) u0)
+  (if (> total-assets u0)
+    (let ((u (/ (* open-interest one-12) total-assets)))
+      (if (<= u MAX-UTILIZATION) u MAX-UTILIZATION))
+    u0)
 )
 
 (define-read-only (get-ir (total-assets uint) (open-interest uint))

--- a/contracts/modules/pyth-adapter-v1.clar
+++ b/contracts/modules/pyth-adapter-v1.clar
@@ -11,8 +11,11 @@
 (define-constant ERR-INVALID-TIME-DELTA (err u80007))
 
 (define-constant STACKS_BLOCK_TIME (contract-call? .constants-v1 get-stacks-block-time ))
-;; Minimum time delta of 1 minute.
-(define-constant MINIMUM_TIME_DELTA u60)
+;; Minimum time delta of 15 seconds (~2 Stacks blocks). Prevents
+;; governance from setting time-delta to 0 (which would freeze
+;; price-dependent operations) while still allowing tight freshness
+;; during volatile market conditions.
+(define-constant MINIMUM_TIME_DELTA u15)
 ;; Maximum time delta of 2 hours.
 (define-constant MAXIMUM_TIME_DELTA u7200)
 ;; Maximum future timestamp tolerance of 60 seconds.

--- a/contracts/modules/withdrawal-caps-v1.clar
+++ b/contracts/modules/withdrawal-caps-v1.clar
@@ -74,7 +74,7 @@
 (define-private (refill-bucket-amount (last-updated-at uint) (time-now uint) (max-bucket uint) (current-bucket uint) (inflow uint))
   (let (
       (refill-window (get-refill-time-window))
-      (elapsed (if (is-eq last-updated-at u0) refill-window (- time-now last-updated-at)))
+      (elapsed (if (is-eq last-updated-at u0) refill-window (if (> time-now last-updated-at) (- time-now last-updated-at) u0)))
       (refill-amount (if (>= elapsed refill-window) max-bucket (/ (* max-bucket elapsed) refill-window)))
       (new-bucket (min (+ current-bucket refill-amount) max-bucket))
   )

--- a/tests/modules/pyth-adapter.test.ts
+++ b/tests/modules/pyth-adapter.test.ts
@@ -222,11 +222,11 @@ describe("pyth-adapter-v1 time-delta bounds (M-1)", () => {
     expect(result.result).toBeErr(Cl.uint(80007)); // ERR-INVALID-TIME-DELTA
   });
 
-  it("time-delta of 59 rejected", () => {
+  it("time-delta one below minimum rejected", () => {
     const result = simnet.callPublicFn(
       "pyth-adapter-v1",
       "update-time-delta",
-      [Cl.uint(59)],
+      [Cl.uint(14)],
       deployer
     );
     expect(result.result).toBeErr(Cl.uint(80007)); // ERR-INVALID-TIME-DELTA
@@ -246,7 +246,7 @@ describe("pyth-adapter-v1 time-delta bounds (M-1)", () => {
     const result = simnet.callPublicFn(
       "pyth-adapter-v1",
       "update-time-delta",
-      [Cl.uint(60)],
+      [Cl.uint(15)],
       deployer
     );
     expect(result.result).toBeOk(Cl.bool(true));


### PR DESCRIPTION
Four informational findings, one commit each.

**I-04** — `lp-incentives-v2.clar::claim-rewards`. The auth check `(or (is-eq contract-caller user) (is-none on-behalf-of))` made the `on-behalf-of` parameter dead code: any non-self value fails the assertion. Rewards are transferred to `user` regardless of who initiates, so third-party claiming was never a theft vector. Dropping the check restores the original keeper/relayer claim flow. Removed the now-unused `ERR-NOT-AUTHORIZED` constant.

**I-05** — `withdrawal-caps-v1.clar::refill-bucket-amount`. Used raw subtraction `(- time-now last-updated-at)`. Bitcoin's median-time-past rule means consecutive Stacks block timestamps can regress (rare but protocol-valid). Underflow would brick LP deposits, debt borrowing, and collateral ops routed through the caps module until the next monotonic block. Apply the same `(if (> ...) (- ...) u0)` clamp `decay-bucket-amount` already uses.

**I-06** — `pyth-adapter-v1.clar::MINIMUM_TIME_DELTA`. Old `u60` forced prices up to ~9-14 blocks stale at governance's tightest setting. Post-Nakamoto blocks run ~5s observed (4.4-7.6s actual). Lower to `u15` (~2-3 blocks) — enough to keep the time-delta-zero freeze guard, tight enough for governance to enforce real freshness during volatile conditions. Updated the test that expected `u59` to be rejected to use `u14` and the at-minimum acceptance test to use `u15`.

**I-07** — `linear-kinked-ir-v1.clar::utilization-calc` (and the read-only utility variant). When `open-interest > total-assets` (stress / post-socialization), utilization is unbounded; `ir-calc` is linear in utilization above the kink; the Taylor input guard at `MAX-TAYLOR-INPUT (u2e12)` then reverts `accrue-interest`, bricking every protocol op until governance does a two-tx pause/unpause cycle to reset `last-accrued-block-time`.

Cap utilization at `MAX-UTILIZATION = u1e13` (10x / 1000% in 12-fixed) inside `utilization-calc`. Mirrored in `linear-kinked-ir-utility.clar` so off-chain quotes match on-chain accrual. With realistic IR params the cap is unreachable; it only fires at the extreme stress edge where the protocol would otherwise be wedged.

224/224 vitest green.