### PR TITLE
fix: resolve audit findings I-08, I-09, I-10, I-11

### DIFF
--- a/contracts/flash-loan-v1.clar
+++ b/contracts/flash-loan-v1.clar
@@ -10,7 +10,7 @@
 
 
 ;; Errors
-(define-constant ERR_CONTRACT_NOT_ALLOWED (err u110000))
+(define-constant ERR-CONTRACT-NOT-ALLOWED (err u110000))
 (define-constant ERR-NOT-AUTHORIZED (err u110001))
 (define-constant ERR-INVALID-FEE (err u110002))
 
@@ -86,7 +86,7 @@
       (caller contract-caller)
       (callback-contract (contract-of callback))
     )
-    (asserts! (is-contract-allowed callback-contract) ERR_CONTRACT_NOT_ALLOWED)
+    (asserts! (is-contract-allowed callback-contract) ERR-CONTRACT-NOT-ALLOWED)
     ;; transfer funds to user
     (try! (contract-call? .state-v1 transfer-to .mock-usdc caller amount))
     (try! (contract-call? callback on-granite-flash-loan amount flash-loan-fee data))

--- a/contracts/liquidator-v1.clar
+++ b/contracts/liquidator-v1.clar
@@ -12,13 +12,15 @@
 (define-constant MINIMUM_HEALTH_RATIO u100000000)
 ;; Liquidation buffer of 2.00%
 (define-constant LIQUIDATION-BUFFER u2000000)
+;; Minimum number of Stacks blocks between borrow and liquidation. Prevents
+;; same-block borrow-then-liquidate sandwich attacks against oracle updates.
+(define-constant MINIMUM-LIQUIDATION-BLOCK-GAP u6)
 
 ;; ERROR VALUES
 (define-constant ERR-DIVIDE-BY-ZERO (err u30000))
 (define-constant ERR-INTEREST-PARAMS (err u30001))
 (define-constant ERR-NO-POSITION (err u30002))
 (define-constant ERR-USER-POSITION-HEALTHY (err u30003))
-(define-constant ERR-LIQUIDATED-TOO-MUCH (err u30004))
 (define-constant ERR-COLLATERAL-NOT-SUPPORTED (err u30005))
 (define-constant ERR-INSUFFICIENT-BALANCE (err u30006))
 (define-constant ERR-SLIPPAGE (err u30007))
@@ -125,7 +127,7 @@
       maybe-collateral-price
     )))
     (collateral-price (get collateral-price liquidation-info)))
-    (try! (ensure-non-zero-repay-amount liquidator-repay-amount collateral-price))
+    (try! (ensure-non-zero-repay-amount liquidator-repay-amount))
     (ok (get liquidation-info liquidation-info))))
 
 (define-read-only
@@ -253,7 +255,6 @@
   (let
       (
         (collateral-token (contract-of collateral))
-        ;; L-36: enforce minimum 6-block gap between borrowing and liquidation
         (user-position-data (contract-call? .state-v1 get-borrow-repay-params user))
         (position-for-block-check (unwrap! (get user-position user-position-data) ERR-NO-POSITION))
         ;; get liquidation info for the user
@@ -298,9 +299,9 @@
           (get collaterals position-data)
         ))
       )
-      ;; L-36: require at least 6 blocks (~1 min) between borrowing and liquidation
-      (asserts! (>= stacks-block-height (+ (get borrowed-block position-for-block-check) u6)) ERR-LIQUIDATION-NOT-ALLOWED)
-      (try! (ensure-non-zero-repay-amount liquidator-repay-amount collateral-price))
+      ;; Enforce minimum block gap between borrowing and liquidation
+      (asserts! (>= stacks-block-height (+ (get borrowed-block position-for-block-check) MINIMUM-LIQUIDATION-BLOCK-GAP)) ERR-LIQUIDATION-NOT-ALLOWED)
+      (try! (ensure-non-zero-repay-amount liquidator-repay-amount))
       ;; update state
       (try! (contract-call? .state-v1 update-liquidate-collateral-state collateral {
         liquidator: contract-caller,
@@ -498,7 +499,7 @@
     ) collateral-prices) u0
 ))
 
-(define-private (ensure-non-zero-repay-amount (amount uint) (collateral-price uint))
+(define-private (ensure-non-zero-repay-amount (amount uint))
   (if (> amount u0)
     SUCCESS
     ERR-NON-ZERO-REPAY-AMOUNT

--- a/contracts/modules/linear-kinked-ir-utility.clar
+++ b/contracts/modules/linear-kinked-ir-utility.clar
@@ -121,7 +121,7 @@
 ))
 
 (define-private (mul (x uint) (y uint))
-	(/ (+ (* x y) (/ one-12 u2)) one-12)
+	(/ (* x y) one-12)
 )
 
 (define-private (div (x uint) (y uint))

--- a/contracts/modules/pyth-adapter-v1.clar
+++ b/contracts/modules/pyth-adapter-v1.clar
@@ -133,7 +133,11 @@
       
     )
     (asserts! (> price 0) ERR-INVALID-PRICE)
-    (asserts! (and (>= expo -18) (<= expo 18)) ERR-INVALID-EXPONENT)
+    ;; Upper bound 11 is the max safe value: pyth_max_int64 (~9.2e18)
+    ;; * 10^(expo+PRICE_DECIMALS) must not exceed clarity_max_int128
+    ;; (~1.7e38). With PRICE_DECIMALS = 8, expo <= 11 holds the product
+    ;; below the overflow threshold for any valid Pyth price.
+    (asserts! (and (>= expo -18) (<= expo 11)) ERR-INVALID-EXPONENT)
     (asserts! (is-valid timestamp) ERR-PYTH-PRICE-STALE)
     (try! (check-confidence (to-uint price) price-conf max-confidence-ratio))
     (ok (to-uint (convert-res price expo PRICE_DECIMALS)))

--- a/contracts/modules/withdrawal-caps-v1.clar
+++ b/contracts/modules/withdrawal-caps-v1.clar
@@ -269,7 +269,7 @@
     (asserts! (<= new-cap SCALING-FACTOR) ERR-INVALID-CAP-FACTOR)
     (print {
       action: "set-debt-cap",
-      old-value: (var-get lp-cap-factor),
+      old-value: (var-get debt-cap-factor),
       new-value: new-cap
     })
     (var-set debt-cap-factor new-cap)

--- a/contracts/staking-v1.clar
+++ b/contracts/staking-v1.clar
@@ -208,7 +208,7 @@
       (active-staked-lp-tokens-to-slash (- lp-tokens withdrawal-lp-tokens-to-slash))
     ) 
     (try! (contract-call? .state-v1 is-allowed-contract contract-caller))
-    (var-set total-lp-tokens-staked (contract-call? .math-v1 safe-sub (var-get total-lp-tokens-staked) active-staked-lp-tokens-to-slash))
+    (var-set total-lp-tokens-staked (- (var-get total-lp-tokens-staked) active-staked-lp-tokens-to-slash))
     (if (is-eq withdrawal-lp-tokens withdrawal-lp-tokens-to-slash)
       (var-set unfinalized-withdrawals {
         lp-tokens: u0,

--- a/tests/flash-loan.test.ts
+++ b/tests/flash-loan.test.ts
@@ -75,7 +75,7 @@ describe("Flash loan tests", () => {
       user1
     );
 
-    expect(res.result).toBeErr(Cl.uint(110000)); // ERR_CONTRACT_NOT_ALLOWED
+    expect(res.result).toBeErr(Cl.uint(110000)); // ERR-CONTRACT-NOT-ALLOWED
   });
 
   it("Not enough USDC on state contract", async () => {


### PR DESCRIPTION
Four informational findings, one commit each.

**I-08** — `staking-v1.clar::slash-total-staked-lp-tokens` used `math-v1::safe-sub` on `(total-lp-tokens-staked - active-staked-lp-tokens-to-slash)`. The only caller path (`liquidator-v1::socialize-bad-debt` → `state-v1::slash-staked-lp-tokens`) caps `lp-tokens` at `get-total-staked-lp-tokens` (active + withdrawal), so `active-staked-lp-tokens-to-slash <= active` and the subtraction cannot underflow. Replace with raw `-`.

**I-09** — multi-site cleanup:

- `flash-loan-v1.clar`: rename `ERR_CONTRACT_NOT_ALLOWED` to `ERR-CONTRACT-NOT-ALLOWED` for naming consistency
- `liquidator-v1.clar`: drop unused `ERR-LIQUIDATED-TOO-MUCH` constant; remove `L-36:` audit ID markers from two inline comments; extract the `u6` block-gap to `MINIMUM-LIQUIDATION-BLOCK-GAP`; drop the unused `collateral-price` parameter from `ensure-non-zero-repay-amount` and update both call sites
- `withdrawal-caps-v1.clar`: fix copy-paste bug in `set-debt-cap`'s print payload — was logging `lp-cap-factor` as the "old" debt cap value

**I-10** — `linear-kinked-ir-utility::mul` used banker's rounding (`(+ (* x y) (/ one-12 u2))` before dividing) while the production `linear-kinked-ir-v1::mul` uses floor division. Off-chain projections via the utility variant drifted slightly higher than on-chain accrual, compounding through the 6 Taylor terms. Drop the +one-12/2 so utility matches production.

**I-11** — `pyth-adapter-v1::decode-pyth` accepted `expo` in `[-18, 18]`. For `expo > 11`, the normalization `price * 10^(expo + PRICE_DECIMALS)` overflows Clarity's int128 (~1.7e38) when the Pyth price approaches int64 max (~9.2e18). Overflow is an uncatchable runtime abort, so a maliciously-set high-exponent feed would DoS every price-dependent op for that token. Tighten the upper bound to `11` (no real Pyth feed uses positive exponents, but governance is the only guard).

224/224 vitest green.