### PR TITLE
fix(R-I-01): close out three miscellaneous code-quality remnants

### DIFF
--- a/contracts/modules/linear-kinked-ir-utility.clar
+++ b/contracts/modules/linear-kinked-ir-utility.clar
@@ -13,6 +13,7 @@
 (define-constant seconds-in-year u31536000)
 ;; Matches MAX-UTILIZATION in linear-kinked-ir-v1.clar -- keep in sync.
 (define-constant MAX-UTILIZATION u10000000000000)
+(define-constant MAX-TAYLOR-INPUT u2000000000000)
 
 
 ;; READ-ONLY FUNCTIONS
@@ -79,7 +80,12 @@
   (ir-calc (utilization-calc total-assets open-interest) ir-slope-1 ir-slope-2 utilization-kink base-ir))
 
 (define-private (compounded-interest (current-interest-rate uint) (elapsed-block-time uint))
-  (taylor-6 (get-rt-by-block current-interest-rate elapsed-block-time)))
+  (let ((rt (get-rt-by-block current-interest-rate elapsed-block-time)))
+    (if (<= rt MAX-TAYLOR-INPUT)
+      (taylor-6 rt)
+      u0
+    )
+  ))
 
 
 (define-private (calc-total-interest (ir uint) (open-ir uint))

--- a/contracts/staking-v1.clar
+++ b/contracts/staking-v1.clar
@@ -17,7 +17,6 @@
 
 ;; Constants
 (define-constant SUCCESS (ok true))
-(define-constant SCALING-FACTOR u100000000)
 
 ;; lp-token
 (define-constant token-prefix "gusdc")

--- a/contracts/staking-v1.clar
+++ b/contracts/staking-v1.clar
@@ -14,6 +14,7 @@
 (define-constant ERR-NOT-GOVERNANCE (err u60007))
 (define-constant ERR-INTEREST-PARAMS (err u60008))
 (define-constant ERR-STAKING-DISABLED (err u60009))
+(define-constant ERR-STAKING-WIPED-OUT (err u60010))
 
 ;; Constants
 (define-constant SUCCESS (ok true))
@@ -362,9 +363,12 @@
     (staking-disabled (not (contract-call? .state-v1 is-staking-enabled)))
     (wiped-out (var-get staking-wiped-out))
   )
-    (if (or staking-disabled wiped-out)
-      ERR-STAKING-DISABLED
-      (ok true)
+    (if wiped-out
+      ERR-STAKING-WIPED-OUT
+      (if staking-disabled
+        ERR-STAKING-DISABLED
+        (ok true)
+      )
     )
   )
 )


### PR DESCRIPTION
ABA's R-I-01 fix-verification row flagged three loose ends from the I-09 family. Bundled fixes here; each is its own commit so they're easy to review independently.

- **Taylor input guard in the utility IR contract.** `linear-kinked-ir-utility.compounded-interest` skipped the `MAX-TAYLOR-INPUT` assertion that production has at L140-146 and passed the result of `get-rt-by-block` straight into `taylor-6`. On-chain that's fine post-I-07 (MAX-UTILIZATION caps the input), but the utility is a read-only / off-chain helper where callers can pass arbitrary IR parameters. The utility's `compounded-interest` returns a plain uint, not a response, so the guard returns `u0` on out-of-bounds instead of erroring — a clearly-wrong sentinel that off-chain callers can detect.
- **Split staking error codes.** `check-staking-enabled` returned `ERR-STAKING-DISABLED (u60009)` for both the reversible governance-disabled state and the permanent wiped-out state. Adds `ERR-STAKING-WIPED-OUT (u60010)` and checks the wiped flag first (it takes precedence since it's permanent). Off-chain monitoring no longer has to query `is-staking-wiped-out` separately to distinguish the two.
- **Drop unused `SCALING-FACTOR` constant** in `staking-v1`. Dead code from a prior version; no reference anywhere in the contract.

230/230 vitest green.

Closes R-I-01.