### PR TITLE
fix: staking share-inflation guard via initialize + dead shares (E-L-01)

### DIFF
--- a/contracts/staking-v1.clar
+++ b/contracts/staking-v1.clar
@@ -15,9 +15,15 @@
 (define-constant ERR-INTEREST-PARAMS (err u60008))
 (define-constant ERR-STAKING-DISABLED (err u60009))
 (define-constant ERR-STAKING-WIPED-OUT (err u60010))
+(define-constant ERR-ALREADY-INITIALIZED (err u60011))
+(define-constant ERR-NOT-INITIALIZED (err u60012))
+(define-constant ERR-NOT-DEPLOYER (err u60013))
 
 ;; Constants
 (define-constant SUCCESS (ok true))
+(define-constant MINIMUM_INITIAL_STAKE u1000)
+(define-constant NULL_ADDRESS (unwrap-panic (principal-construct? (if is-in-mainnet 0x16 0x1a) 0x0000000000000000000000000000000000000000)))
+(define-constant contract-deployer contract-caller)
 
 ;; lp-token
 (define-constant token-prefix "gusdc")
@@ -29,6 +35,7 @@
 (define-map user-withdrawals { user: principal, index: uint } { withdrawal-shares: uint, finalization-at: uint })
 (define-data-var total-lp-tokens-staked uint u0)
 (define-data-var staking-wiped-out bool false)
+(define-data-var initialized bool false)
 
 ;; governance
 (define-public (update-withdrawal-finalization-period (new-value uint))
@@ -164,6 +171,33 @@
 )
 
 ;; Public functions
+(define-public (initialize (min-stake (optional uint)))
+  (let (
+      (stake-amount (default-to MINIMUM_INITIAL_STAKE min-stake))
+      (total-staked (ft-get-supply staked-lp-token))
+      (dust-burned (is-eq total-staked u0))
+      (initial-balance (ft-get-balance staked-lp-token contract-caller))
+    )
+    (asserts! (is-eq contract-caller contract-deployer) ERR-NOT-DEPLOYER)
+    (asserts! (not (var-get initialized)) ERR-ALREADY-INITIALIZED)
+    (var-set initialized true)
+    (try! (if (and dust-burned (> stake-amount u0))
+      (begin
+        (try! (stake stake-amount))
+        (transfer (- (ft-get-balance staked-lp-token contract-caller) initial-balance) contract-caller NULL_ADDRESS none)
+      )
+      SUCCESS
+    ))
+    (print {
+      action: "initialized",
+      user: contract-caller,
+      total-staked: total-staked,
+      dust-burned: dust-burned,
+    })
+    SUCCESS
+  )
+)
+
 (define-public (stake (lp-tokens uint))
   (begin
     (try! (check-staking-enabled))
@@ -172,6 +206,7 @@
         (staked-lp-tokens-to-mint (convert-to-staked-lp-tokens lp-tokens false))
       )
       (asserts! (> lp-tokens u0) ERR-ZERO-LP-TOKEN-STAKE)
+      (asserts! (var-get initialized) ERR-NOT-INITIALIZED)
       (try! (contract-call? .state-v1 transfer lp-tokens contract-caller (as-contract contract-caller) none))
       (try! (ft-mint? staked-lp-token staked-lp-tokens-to-mint contract-caller))
       (var-set total-lp-tokens-staked (+ (var-get total-lp-tokens-staked) lp-tokens))

--- a/tests/poc-el01-staking-inflation.test.ts
+++ b/tests/poc-el01-staking-inflation.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+import {
+  deposit,
+  initialize_ir,
+  initialize_lp,
+  initialize_staking,
+  initialize_staking_reward,
+  mint_token,
+  set_allowed_contracts,
+  set_asset_cap,
+  MINIMUM_INITIAL_STAKE,
+} from "./utils";
+import { init_pyth, set_pyth_time_delta, set_initial_price } from "./pyth";
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const staker = accounts.get("wallet_1")!;
+
+describe("PoC E-L-01: staking share-inflation guard", () => {
+  beforeEach(async () => {
+    init_pyth(deployer);
+    set_pyth_time_delta(7200, deployer);
+    set_allowed_contracts(deployer);
+    set_asset_cap(deployer, 10_000_000_000_000n);
+    initialize_ir(deployer);
+    initialize_staking_reward(deployer);
+    initialize_lp(deployer);
+    await set_initial_price("mock-usdc", 1n, deployer);
+  });
+
+  it("stake is blocked until initialize seeds the dead shares", () => {
+    mint_token("mock-usdc", 5000, staker);
+    deposit(5000, staker);
+
+    const beforeInit = simnet.callPublicFn("staking-v1", "stake", [Cl.uint(1000)], staker);
+    expect(beforeInit.result).toBeErr(Cl.uint(60012));
+
+    initialize_staking(deployer, MINIMUM_INITIAL_STAKE);
+
+    const afterInit = simnet.callPublicFn("staking-v1", "stake", [Cl.uint(1000)], staker);
+    expect(afterInit.result).toBeOk(Cl.bool(true));
+  });
+
+  it("initialize is deployer-only, seeds the dead-share floor, and rejects a second call", () => {
+    const byStaker = simnet.callPublicFn("staking-v1", "initialize", [Cl.none()], staker);
+    expect(byStaker.result).toBeErr(Cl.uint(60013));
+
+    initialize_staking(deployer, MINIMUM_INITIAL_STAKE);
+
+    const supply = simnet.callReadOnlyFn("staking-v1", "get-total-supply", [], deployer);
+    expect(supply.result).toBeOk(Cl.uint(Number(MINIMUM_INITIAL_STAKE)));
+
+    const second = simnet.callPublicFn("staking-v1", "initialize", [Cl.none()], deployer);
+    expect(second.result).toBeErr(Cl.uint(60011));
+  });
+});

--- a/tests/poc-slash-underflow.test.ts
+++ b/tests/poc-slash-underflow.test.ts
@@ -31,6 +31,7 @@ import {
   borrow,
   initialize_staking_reward,
   initialize_lp,
+  initialize_staking,
 } from "./utils";
 import {
   init_pyth,
@@ -96,6 +97,7 @@ describe("PoC: slash-total-staked-lp-tokens underflow", () => {
     initialize_lp(deployer);
     await set_initial_price("mock-usdc", 1n, deployer);
     await set_initial_price("mock-btc", 100n, deployer);
+    initialize_staking(deployer);
   });
 
   it("bad-debt liquidation reverts when unfinalized withdrawals cause slash underflow", async () => {

--- a/tests/staking.test.ts
+++ b/tests/staking.test.ts
@@ -9,6 +9,7 @@ import {
   transfer_token,
   initialize_staking_reward,
   initialize_lp,
+  initialize_staking,
   deposit_and_borrow,
   repay,
   update_supported_collateral,
@@ -134,6 +135,7 @@ describe("staking tests", () => {
     initialize_lp(deployer);
     await set_initial_price("mock-usdc", 1n, deployer);
     await set_initial_price("mock-btc", 10n, deployer);
+    initialize_staking(deployer);
   });
 
   it("should stake lp tokens", async () => {
@@ -536,7 +538,7 @@ describe("staking tests", () => {
     // accrued interest math to settle a slightly different staked-LP total.
     expectUserLpBalance(
       Cl.contractPrincipal(deployer, "staking-v1"),
-      500054691220n
+      500054682070n
     );
 
     // initiate unstake of depositor 1 at index 0
@@ -546,7 +548,7 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     const withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500054691220));
+    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500054682070));
     expect(withdrawal.data["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
@@ -558,7 +560,7 @@ describe("staking tests", () => {
 
     // depositor1 got full lp tokens of staking contract.
     // Post H-01: 2-block init shift slightly changes accrued-interest math.
-    expectUserLpBalance(Cl.principal(depositor1), 1000054691220n);
+    expectUserLpBalance(Cl.principal(depositor1), 1000054682070n);
     expectUserStakedLpBalance(Cl.principal(depositor1), 0n);
     expectUserLpBalance(Cl.contractPrincipal(deployer, "staking-v1"), 0n);
   });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -213,6 +213,22 @@ export const initialize_lp = (deployer: any) => {
   expect(response.result).toBeOk(Cl.bool(true));
 };
 
+export const MINIMUM_INITIAL_STAKE = 1000n;
+
+export const initialize_staking = (deployer: any, minStake: bigint = 0n) => {
+  if (minStake > 0n) {
+    mint_token("mock-usdc", Number(minStake), deployer);
+    deposit(Number(minStake), deployer);
+  }
+  const response = simnet.callPublicFn(
+    "staking-v1",
+    "initialize",
+    [Cl.some(Cl.uint(minStake))],
+    deployer
+  );
+  expect(response.result).toBeOk(Cl.bool(true));
+};
+
 export const set_allowed_contracts = (deployer: any) => {
   let contracts = [
     Cl.contractPrincipal(deployer, "liquidity-provider-v1"),


### PR DESCRIPTION
Fixes E-L-01, the staking-side twin of the H-01 LP inflation attack. The staking vault let the first staker mint shares 1:1 with no floor, so they could inflate the share price through zero-cost stake/unstake cycles and then skim from a later staker's deposit, or DoS small stakes that round to zero shares.

The fix mirrors H-01: an `initialize` that seeds a minimum stake and burns those shares to the null address as permanent dead shares, with `stake` gated on initialize having run. The min-stake is an optional argument defaulting to the production minimum, so tests can override it (pass 0 to skip the perturbation, or the real floor to exercise the guard). initialize is deployer-only and runs exactly once.

PoC in tests/poc-el01-staking-inflation.test.ts covers it end to end: stake is blocked before initialize, a non-deployer caller is rejected, the dead-share floor lands, and a second initialize fails. Deployment needs to call initialize once after publishing the contract.
