### PR TITLE
fix: socialize bad debt once collateral is unseizable, not only at zero

### DIFF
--- a/contracts/liquidator-v1.clar
+++ b/contracts/liquidator-v1.clar
@@ -494,9 +494,26 @@
     (if (< collateral-value (+ current-debt collateral-reward)) true false)
 ))
 
-(define-private (get-user-total-collateral-value (user principal) (position-collaterals (list 10 principal)) (collateral-prices (list 10 uint)))
+;; What a liquidation could still seize from this collateral at a full-value
+;; repay; 0 for dust the liquidation math can never extract (the conversion
+;; floors to 0 and state-v1.transfer-to rejects a 0-amount transfer).
+(define-private (max-seizable-for-collateral (collateral principal) (user principal) (collateral-price uint))
+  (let (
+      (info (contract-call? .state-v1 get-collateral collateral))
+      (deposited (default-to u0 (get amount (contract-call? .state-v1 get-user-collateral user collateral))))
+      (decimals (default-to u8 (get decimals info)))
+      (premium (default-to u0 (get liquidation-premium info)))
+      (collateral-value (get-collateral-value collateral user collateral-price))
+      (repay-without-discount (contract-call? .math-v1 divide-round-up (* collateral-value SCALING-FACTOR) (+ premium SCALING-FACTOR)))
+    )
+    (match (calc-collateral-to-give repay-without-discount premium collateral-price decimals deposited)
+      seizable seizable
+      e u0)
+  ))
+
+(define-private (total-max-seizable (user principal) (position-collaterals (list 10 principal)) (collateral-prices (list 10 uint)))
   (fold +
-    (map get-collateral-value position-collaterals (
+    (map max-seizable-for-collateral position-collaterals (
         list user user user user user user user user user user
     ) collateral-prices) u0
 ))
@@ -517,12 +534,12 @@
         (total-borrowed-amount (get total-borrowed-amount repay-params))
         (user-collaterals (get collaterals position))
         (collateral-prices (try! (contract-call? .pyth-adapter-v1 bulk-read-collateral-prices user-collaterals)))
-        (total-collateral-value (get-user-total-collateral-value user user-collaterals collateral-prices))
         (debt-params (contract-call? .state-v1 get-debt-params))
         (remaining-debt (contract-call? .math-v1 convert-to-debt-assets debt-params (get debt-shares position) true))
       )
-      
-      (if (or (> total-collateral-value u0) (is-eq remaining-debt u0))
+
+      ;; socialize once no collateral is still seizable; unseizable dust must not block it
+      (if (or (> (total-max-seizable user user-collaterals collateral-prices) u0) (is-eq remaining-debt u0))
         SUCCESS
         (let (
             (user-borrowed-amount (get borrowed-amount position))

--- a/tests/poc-dust-socialization.test.ts
+++ b/tests/poc-dust-socialization.test.ts
@@ -1,0 +1,167 @@
+// Regression guard for the bad-debt socialization fix: it must NOT over-socialize.
+//
+// The fix makes socialize-bad-debt fire once no collateral is still SEIZABLE,
+// rather than only when collateral value hits exactly zero. This guards the
+// other side of that line: while genuinely seizable collateral remains, a
+// bad-debt liquidation must still DEFER socialization, so liquidators recover
+// that collateral first and the borrower's collateral is not written off while
+// it is still recoverable. Full seizure must still socialize the uncovered loss.
+//
+// One insolvent bad-debt position (collateral value 800 << debt 1400), two ways:
+//   * partial liquidation leaving SEIZABLE collateral -> defers (no writedown).
+//   * full seizure                                    -> socializes the loss.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Cl, ClarityType, contractPrincipalCV } from "@stacks/transactions";
+import {
+  add_collateral,
+  borrow,
+  deposit,
+  initialize_lp,
+  initialize_staking_reward,
+  mint_token,
+  set_allowed_contracts,
+  set_asset_cap,
+  update_supported_collateral,
+} from "./utils";
+import { init_pyth, set_pyth_time_delta, set_initial_price, set_price } from "./pyth";
+
+const initialize_ir_zero = (deployer: string) => {
+  const res = simnet.callPublicFn(
+    "linear-kinked-ir-v1",
+    "update-ir-params",
+    [Cl.uint(0), Cl.uint(0), Cl.uint(700_000_000_000), Cl.uint(0)],
+    deployer,
+  );
+  expect(res.result.type).toBe(ClarityType.ResponseOk);
+};
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const depositor = accounts.get("wallet_4")!;
+const borrower = accounts.get("wallet_1")!;
+const liquidator = accounts.get("wallet_5")!;
+const btc_collateral = contractPrincipalCV(deployer, "mock-btc");
+
+const getTotalAssets = (): bigint => {
+  const r = simnet.callReadOnlyFn("state-v1", "get-lp-params", [], deployer);
+  return r.result.data["total-assets"].value as bigint;
+};
+
+const getDebtShares = (user: string): bigint => {
+  const r = simnet.callReadOnlyFn(
+    "state-v1",
+    "get-borrow-repay-params",
+    [Cl.principal(user)],
+    deployer,
+  );
+  return r.result.data["user-position"].value.data["debt-shares"].value as bigint;
+};
+
+const getBtcCollateral = (user: string): bigint => {
+  const r = simnet.callReadOnlyFn(
+    "state-v1",
+    "get-user-collateral",
+    [Cl.principal(user), btc_collateral],
+    deployer,
+  );
+  if (r.result.type !== ClarityType.OptionalSome) return 0n;
+  return r.result.value.data["amount"].value as bigint;
+};
+
+const socializeFired = (result: any): boolean =>
+  JSON.stringify(result.events).includes("socialized-bad-debt");
+
+// Deposit 1,000,000; open a position (16 btc collateral @ price 100 -> value
+// 1600, borrow 1400 at 87.5% LTV); then crash btc to 50 so collateral value is
+// 800 << debt 1400 -> the position is genuinely insolvent and bad-debt flagged.
+const setupInsolventPosition = async () => {
+  mint_token("mock-usdc", 1_000_000, depositor);
+  deposit(1_000_000, depositor);
+
+  update_supported_collateral("mock-btc", 90_000_000, 95_000_000, 5_000_000, 8, deployer);
+  mint_token("mock-btc", 16, borrower);
+  add_collateral("mock-btc", 16, deployer, borrower);
+  borrow(1400, borrower);
+
+  mint_token("mock-usdc", 1_000_000, liquidator);
+  simnet.mineEmptyBlocks(6);
+
+  // Refresh both prices (fresh VAAs) and crash btc to 50.
+  await set_price("mock-usdc", 1n, deployer);
+  await set_price("mock-btc", 50n, deployer);
+};
+
+describe("Socialization fix guard: seizable collateral defers, full seizure socializes", () => {
+  beforeEach(async () => {
+    init_pyth(deployer);
+    set_pyth_time_delta(7200, deployer);
+    set_allowed_contracts(deployer);
+    set_asset_cap(deployer, 10_000_000_000_000n);
+    initialize_ir_zero(deployer);
+    initialize_staking_reward(deployer);
+    initialize_lp(deployer);
+    await set_initial_price("mock-usdc", 1n, deployer);
+    await set_initial_price("mock-btc", 100n, deployer);
+  });
+
+  it("partial liquidation leaving seizable collateral defers socialization (no over-socialization)", async () => {
+    await setupInsolventPosition();
+
+    const taBefore = getTotalAssets();
+
+    // Repay a sliver (100 of ~1400 debt). Seizes a little collateral, leaves the rest.
+    const res = simnet.callPublicFn(
+      "liquidator-v1",
+      "liquidate-collateral",
+      [Cl.none(), btc_collateral, Cl.principal(borrower), Cl.uint(100), Cl.uint(1)],
+      liquidator,
+    );
+    expect(res.result.type).toBe(ClarityType.ResponseOk);
+
+    const taAfter = getTotalAssets();
+    const btcLeft = getBtcCollateral(borrower);
+    const debtShares = getDebtShares(borrower);
+    console.log(
+      `[skip] taBefore=${taBefore} taAfter=${taAfter} btcLeft=${btcLeft} debtShares=${debtShares} socialized=${socializeFired(res)}`,
+    );
+
+    // Seizable collateral remains, so the liquidation correctly defers: a later
+    // liquidation recovers that collateral before any writedown.
+    expect(btcLeft).toBeGreaterThan(0n);
+    expect(socializeFired(res)).toBe(false);
+    // total-assets is unchanged and the position keeps its debt - nothing is
+    // written off while collateral is still recoverable (no over-socialization).
+    expect(taAfter).toBe(taBefore);
+    expect(debtShares).toBeGreaterThan(0n);
+  });
+
+  it("full collateral seizure of the same position socializes the uncovered loss", async () => {
+    await setupInsolventPosition();
+
+    const taBefore = getTotalAssets();
+
+    // Repay 762 -> seizes all 16 collateral (800/(1.05) maps to the full deposit)
+    // while leaving debt uncovered, so remaining-debt > 0 and collateral hits 0.
+    const res = simnet.callPublicFn(
+      "liquidator-v1",
+      "liquidate-collateral",
+      [Cl.none(), btc_collateral, Cl.principal(borrower), Cl.uint(762), Cl.uint(1)],
+      liquidator,
+    );
+    expect(res.result.type).toBe(ClarityType.ResponseOk);
+
+    const taAfter = getTotalAssets();
+    const btcLeft = getBtcCollateral(borrower);
+    const debtShares = getDebtShares(borrower);
+    console.log(
+      `[fire] taBefore=${taBefore} taAfter=${taAfter} btcLeft=${btcLeft} debtShares=${debtShares} socialized=${socializeFired(res)}`,
+    );
+
+    // All collateral seized -> total-collateral-value == 0 -> socialization runs.
+    expect(btcLeft).toBe(0n);
+    expect(socializeFired(res)).toBe(true);
+    // total-assets is written down by the uncollateralised loss.
+    expect(taAfter).toBeLessThan(taBefore);
+  });
+});

--- a/tests/poc-dust-unseizable.test.ts
+++ b/tests/poc-dust-unseizable.test.ts
@@ -1,0 +1,125 @@
+// Regression: unseizable-dust no longer blocks bad-debt socialization.
+//
+// Pre-fix, a bad-debt position partially liquidated down to an unseizable
+// collateral dust could never be socialized: the gate skipped while any
+// collateral value remained, and the dust could not be driven to zero (the
+// conversion floored collateral-to-give to 0 and state-v1.transfer-to rejects a
+// 0-amount transfer), so every clearing liquidation reverted with
+// ERR-TRANSFER-NULL and the loss was stranded forever.
+//
+// Post-fix, socialize-bad-debt fires once no collateral is still seizable, so
+// the liquidation that leaves the dust recognizes the loss in the same call.
+// Scenario mirrors the original report (8-dec market+collateral, btc
+// $60k -> ~$20k, 1.00000101 btc collateral, 30000 borrow).
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Cl, ClarityType, contractPrincipalCV } from "@stacks/transactions";
+import {
+  add_collateral,
+  borrow,
+  deposit,
+  initialize_lp,
+  initialize_staking_reward,
+  mint_token,
+  set_allowed_contracts,
+  set_asset_cap,
+  update_supported_collateral,
+} from "./utils";
+import { init_pyth, set_pyth_time_delta, set_initial_price, set_price_without_scaling } from "./pyth";
+
+const initialize_ir_zero = (deployer: string) => {
+  const res = simnet.callPublicFn(
+    "linear-kinked-ir-v1",
+    "update-ir-params",
+    [Cl.uint(0), Cl.uint(0), Cl.uint(700_000_000_000), Cl.uint(0)],
+    deployer,
+  );
+  expect(res.result.type).toBe(ClarityType.ResponseOk);
+};
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const depositor = accounts.get("wallet_4")!;
+const borrower = accounts.get("wallet_1")!;
+const liquidator = accounts.get("wallet_5")!;
+const btc = contractPrincipalCV(deployer, "mock-btc");
+
+const getBtcCollateral = (user: string): bigint => {
+  const r = simnet.callReadOnlyFn("state-v1", "get-user-collateral", [Cl.principal(user), btc], deployer);
+  if (r.result.type !== ClarityType.OptionalSome) return 0n;
+  return r.result.value.data["amount"].value as bigint;
+};
+const getDebtShares = (user: string): bigint => {
+  const r = simnet.callReadOnlyFn("state-v1", "get-borrow-repay-params", [Cl.principal(user)], deployer);
+  return r.result.data["user-position"].value.data["debt-shares"].value as bigint;
+};
+const getTotalAssets = (): bigint => {
+  const r = simnet.callReadOnlyFn("state-v1", "get-lp-params", [], deployer);
+  return r.result.data["total-assets"].value as bigint;
+};
+const socializeFired = (res: any): boolean => JSON.stringify(res.events).includes("socialized-bad-debt");
+const liquidate = (repay: bigint, minCol: bigint) =>
+  simnet.callPublicFn(
+    "liquidator-v1",
+    "liquidate-collateral",
+    [Cl.none(), btc, Cl.principal(borrower), Cl.uint(repay), Cl.uint(minCol)],
+    liquidator,
+  );
+
+describe("Regression: unseizable dust no longer blocks bad-debt socialization", () => {
+  beforeEach(async () => {
+    init_pyth(deployer);
+    set_pyth_time_delta(7200, deployer);
+    set_allowed_contracts(deployer);
+    set_asset_cap(deployer, 1_000_000_000_000_000n);
+    initialize_ir_zero(deployer);
+    initialize_staking_reward(deployer);
+    initialize_lp(deployer);
+    await set_initial_price("mock-usdc", 1n, deployer);
+    await set_initial_price("mock-btc", 60000n, deployer);
+  });
+
+  it("a liquidation that leaves unseizable dust socializes the bad debt in the same call", async () => {
+    mint_token("mock-usdc", 50000_00000000, depositor);
+    deposit(50000_00000000, depositor);
+
+    update_supported_collateral("mock-btc", 51000000, 65000000, 10000000, 8, deployer);
+    mint_token("mock-btc", 1_00000101, borrower);
+    add_collateral("mock-btc", 1_00000101, deployer, borrower);
+    borrow(30000_00000000, borrower);
+
+    // Crash btc to ~$20k -> collateral ~$20k < debt $30k -> bad debt.
+    await set_price_without_scaling("mock-btc", 1999923495619n, deployer);
+
+    mint_token("mock-usdc", 1_000_000_00000000, liquidator);
+    simnet.mineEmptyBlocks(6);
+
+    const taBefore = getTotalAssets();
+
+    // This liquidation seizes almost all collateral, leaving a 1-sat unseizable
+    // remainder. Pre-fix it reverted the position into a permanent stranded
+    // state; post-fix it socializes the uncovered debt in this same call.
+    const liq1 = liquidate(1818114105036n, 1n);
+    const dust = getBtcCollateral(borrower);
+    const debtShares = getDebtShares(borrower);
+    const taAfter = getTotalAssets();
+    console.log(`[liq1] result=${liq1.result.type === ClarityType.ResponseOk ? "ok" : "err"} socialized=${socializeFired(liq1)} dust=${dust} debtShares=${debtShares} taBefore=${taBefore} taAfter=${taAfter}`);
+
+    expect(liq1.result.type).toBe(ClarityType.ResponseOk);
+    // The loss is recognized in this same liquidation...
+    expect(socializeFired(liq1)).toBe(true);
+    // ...the bad debt is written off the position...
+    expect(debtShares).toBe(0n);
+    // ...and total-assets is written down by the uncovered loss.
+    expect(taAfter).toBeLessThan(taBefore);
+
+    // The unseizable dust may remain on the now debt-free position - harmless.
+    // It is no longer a stuck bad-debt: a further liquidation is rejected as a
+    // healthy position (ERR-USER-POSITION-HEALTHY u30003), not stranded on the
+    // zero-amount transfer guard (ERR-TRANSFER-NULL u101).
+    const followUp = liquidate(100000000000000n, 0n);
+    console.log(`[follow-up] err=${followUp.result.value?.value}`);
+    expect(followUp.result.type).toBe(ClarityType.ResponseErr);
+    expect(followUp.result.value.value).toBe(30003n);
+  });
+});


### PR DESCRIPTION
The liquidator's bad-debt socialization can be permanently blocked by a dust amount of collateral that no liquidation can seize. `socialize-bad-debt` only wrote the loss down once a position's collateral value reached exactly zero, but a position can be left with a sliver of collateral that the seizure math floors to a zero amount and `state-v1.transfer-to` then rejects (it won't move zero). That last unit can never be cleared, so collateral never reaches zero and the bad debt is never socialized; it stays on the books and grows. On the live market (6-decimal market token, 8-decimal sBTC) a 1-99 sat residual is unseizable at any price, so it's reachable in practice.

The change makes the gate fire once no collateral is still seizable, instead of once collateral value is zero. A helper runs the real collateral-to-give math at a full-value repay per collateral; if every one comes back zero (genuinely unseizable dust), the remaining debt is socialized in that same liquidation. While any collateral is still seizable it defers exactly as before, so liquidators recover that collateral first, and the remaining-debt=0 early exit is kept.

Two regression tests come with it: the unseizable-dust case now socializes in-liquidation, and a still-seizable position still defers (no over-socialization). This is the upgradable liquidator fix; the broader deferred-socialization window (a partial liquidation that leaves still-seizable collateral) needs an in-place shortfall writedown in the immutable state-v1 and is tracked for v2. Closes the dust-socialization finding from Immunefi 80206 / 81664.
