### PR TITLE
migrate oracle from Pyth Core to Pyth Lazer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "contracts/pyth"]
-	path = contracts/pyth
-	url = https://github.com/Trust-Machines/stacks-pyth-bridge

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -75,33 +75,13 @@ path = 'contracts/test/mock-usdc.clar'
 clarity_version = 3
 epoch = 3.0
 
-[contracts.pyth-governance-v3]
-path = 'contracts/pyth/contracts/pyth-governance-v3.clar'
-clarity_version = 3
-epoch = 3.0
-
 [contracts.pyth-adapter-v1]
 path = 'contracts/modules/pyth-adapter-v1.clar'
 clarity_version = 3
 epoch = 3.0
 
-[contracts.pyth-oracle-v4]
-path = 'contracts/pyth/contracts/pyth-oracle-v4.clar'
-clarity_version = 3
-epoch = 3.0
-
-[contracts.pyth-pnau-decoder-v3]
-path = 'contracts/pyth/contracts/pyth-pnau-decoder-v3.clar'
-clarity_version = 3
-epoch = 3.0
-
-[contracts.pyth-storage-v4]
-path = 'contracts/pyth/contracts/pyth-storage-v4.clar'
-clarity_version = 3
-epoch = 3.0
-
-[contracts.pyth-traits-v2]
-path = 'contracts/pyth/contracts/pyth-traits-v2.clar'
+[contracts.pyth-lazer-storage]
+path = 'contracts/test/pyth-lazer-storage.clar'
 clarity_version = 3
 epoch = 3.0
 
@@ -132,16 +112,6 @@ epoch = 3.0
 
 [contracts.utility]
 path = 'contracts/modules/utility.clar'
-clarity_version = 3
-epoch = 3.0
-
-[contracts.wormhole-core-v4]
-path = 'contracts/pyth/contracts/wormhole/wormhole-core-v4.clar'
-clarity_version = 3
-epoch = 3.0
-
-[contracts.wormhole-traits-v2]
-path = 'contracts/pyth/contracts/wormhole/wormhole-traits-v2.clar'
 clarity_version = 3
 epoch = 3.0
 

--- a/contracts/borrower-v1.clar
+++ b/contracts/borrower-v1.clar
@@ -23,10 +23,9 @@
 (define-constant PRICE-SCALING-FACTOR (contract-call? .constants-v2 get-price-scaling-factor))
 
 ;; PUBLIC FUNCTIONS
-(define-public (borrow (pyth-price-feed-data (optional (buff 8192))) (amount uint) (maybe-user (optional principal)))
+(define-public (borrow (amount uint) (maybe-user (optional principal)))
   (begin
     (try! (contract-call? .withdrawal-caps-v1 check-withdrawal-debt-cap amount))
-    (try! (contract-call? .pyth-adapter-v1 update-pyth pyth-price-feed-data))
     (try! (accrue-interest))
     (asserts! (>= (contract-call? .state-v1 get-borrowable-balance) amount) ERR-INSUFFICIENT-FREE-LIQUIDITY)
     (let
@@ -173,10 +172,9 @@
     )
 ))
 
-(define-public (remove-collateral (pyth-price-feed-data (optional (buff 8192))) (collateral <token-trait>) (amount uint) (maybe-user (optional principal)))
+(define-public (remove-collateral (collateral <token-trait>) (amount uint) (maybe-user (optional principal)))
   (begin
     (try! (contract-call? .withdrawal-caps-v1 check-withdrawal-collateral-cap collateral amount))
-    (try! (contract-call? .pyth-adapter-v1 update-pyth pyth-price-feed-data))
     (try! (accrue-interest))
     (let
       (

--- a/contracts/governance-v1.clar
+++ b/contracts/governance-v1.clar
@@ -233,7 +233,7 @@
 ;; Reserve token feed data
 (define-map update-pyth-feed (buff 32) {
   token: principal,
-  feed: (buff 32),
+  feed: uint,
   max-confidence-ratio: uint,
 })
 
@@ -1269,7 +1269,7 @@
     SUCCESS
 ))
 
-(define-public (initiate-proposal-to-update-pyth-feed (token principal) (feed (buff 32)) (max-confidence-ratio uint) (expires-in uint))
+(define-public (initiate-proposal-to-update-pyth-feed (token principal) (feed uint) (max-confidence-ratio uint) (expires-in uint))
     (let (
       (proposal-nonce (var-get next-proposal-nonce))
       (proposal-id (keccak256 (unwrap! (to-consensus-buff? {

--- a/contracts/liquidator-v1.clar
+++ b/contracts/liquidator-v1.clar
@@ -30,21 +30,19 @@
 (define-constant ERR-LIQUIDATION-NOT-ALLOWED (err u30011))
 
 ;; PUBLIC FUNCTIONS
-(define-public (batch-liquidate (pyth-price-feed-data (optional (buff 8192))) (collateral <token-trait>) (batch (list 20 (optional {
+(define-public (batch-liquidate (collateral <token-trait>) (batch (list 20 (optional {
   user: principal,
   liquidator-repay-amount: uint,
   min-collateral-expected: uint
 }))))
   (begin
-  (try! (contract-call? .pyth-adapter-v1 update-pyth pyth-price-feed-data))
   (try! (accrue-interest))
   (try! (get res (fold fold-execute-liquidation batch {collateral: collateral, res: (ok true)})))
   SUCCESS
 ))
 
-(define-public (liquidate-collateral (pyth-price-feed-data (optional (buff 8192))) (collateral <token-trait>) (user principal) (liquidator-repay-amount uint) (min-collateral-expected uint))
+(define-public (liquidate-collateral (collateral <token-trait>) (user principal) (liquidator-repay-amount uint) (min-collateral-expected uint))
   (begin
-    (try! (contract-call? .pyth-adapter-v1 update-pyth pyth-price-feed-data))
     (try! (accrue-interest))
     (execute-liquidation user collateral liquidator-repay-amount min-collateral-expected)
 ))

--- a/contracts/modules/pyth-adapter-v1.clar
+++ b/contracts/modules/pyth-adapter-v1.clar
@@ -96,16 +96,6 @@
   )
 )
 
-;; Push model: the Lazer relayer keeps pyth-lazer-storage fresh out-of-band, so this
-;; is a no-op kept for interface compatibility. Reads enforce staleness, so a lagging
-;; relayer fails safe. The asserts! pins the response err type to uint so callers can try! it.
-(define-public (update-pyth (maybe-update-buffer (optional (buff 8192))))
-  (begin
-    (asserts! true ERR-NOT-AUTHORIZED)
-    SUCCESS
-  )
-)
-
 (define-read-only (bulk-read-collateral-prices (collaterals (list 10 principal)))
   (fold check-collateral-price-exists collaterals (ok (list)))
 )

--- a/contracts/modules/pyth-adapter-v1.clar
+++ b/contracts/modules/pyth-adapter-v1.clar
@@ -24,17 +24,19 @@
 (define-constant CONFIDENCE_SCALING_FACTOR u10000)
 ;; Price scaling factor decimals
 (define-constant PRICE_DECIMALS (to-int (contract-call? .constants-v2 get-price-decimals)))
+;; Lazer publish-time is microseconds; the staleness check works in seconds.
+(define-constant MICROS_PER_SECOND u1000000)
 
-;; price feeds can be found in https://pyth.network/developers/price-feed-ids
+;; Lazer numeric feed ids (from the Lazer symbol catalog), keyed by token.
 (define-map price-feeds principal {
-  feed-id: (buff 32),
+  feed-id: uint,
   max-confidence-ratio: uint
 })
 (define-data-var time-delta uint u1800)
 
 ;; admin-level maintenance functions
-(define-public (update-price-feed-id (token principal) (new-feed-id (buff 32)) (max-confidence-ratio uint))
-  (begin 
+(define-public (update-price-feed-id (token principal) (new-feed-id uint) (max-confidence-ratio uint))
+  (begin
     (asserts! (is-eq (contract-call? .state-v1 get-governance) contract-caller) ERR-NOT-AUTHORIZED)
     (asserts! (<= max-confidence-ratio CONFIDENCE_SCALING_FACTOR) ERR-INVALID-MAX-CONFIDENCE-RATIO)
     (map-set price-feeds token {
@@ -52,7 +54,7 @@
 ))
 
 (define-public (update-time-delta (delta uint))
-  (begin 
+  (begin
     (asserts! (is-eq (contract-call? .state-v1 get-governance) contract-caller) ERR-NOT-AUTHORIZED)
     (asserts! (>= delta MINIMUM_TIME_DELTA) ERR-INVALID-TIME-DELTA)
     (asserts! (<= delta MAXIMUM_TIME_DELTA) ERR-INVALID-TIME-DELTA)
@@ -74,35 +76,32 @@
 (define-read-only (get-pyth-minimum-time-delta) MINIMUM_TIME_DELTA)
 
 (define-read-only (read-price (token principal))
-  (let 
+  (let
     (
-      (pyth-feed-data (unwrap! (map-get? price-feeds token) ERR-UNSUPPORTED-ASSET))
-      (pyth-record 
-          (try! (contract-call? 
-            .pyth-storage-v4
+      (feed-data (unwrap! (map-get? price-feeds token) ERR-UNSUPPORTED-ASSET))
+      (record
+          (try! (contract-call?
+            .pyth-lazer-storage
             get-price
-            (get feed-id pyth-feed-data)
+            (get feed-id feed-data)
           ))
         )
     )
-    (decode-pyth pyth-record (get max-confidence-ratio pyth-feed-data))
+    (decode-lazer
+      (get price record)
+      (get exponent record)
+      (get publish-time record)
+      (get confidence record)
+      (get max-confidence-ratio feed-data))
   )
 )
 
-(define-public (update-pyth (maybe-vaa-buffer (optional (buff 8192))))
-  (match maybe-vaa-buffer vaa-buffer
-    (begin
-      (try! 
-        (contract-call? .pyth-oracle-v4 verify-and-update-price-feeds 
-          vaa-buffer
-          {
-            pyth-storage-contract: .pyth-storage-v4,
-            pyth-decoder-contract: .pyth-pnau-decoder-v3,
-            wormhole-core-contract: .wormhole-core-v4
-          }) 
-      )
-      SUCCESS
-    )
+;; Push model: the Lazer relayer keeps pyth-lazer-storage fresh out-of-band, so this
+;; is a no-op kept for interface compatibility. Reads enforce staleness, so a lagging
+;; relayer fails safe. The asserts! pins the response err type to uint so callers can try! it.
+(define-public (update-pyth (maybe-update-buffer (optional (buff 8192))))
+  (begin
+    (asserts! true ERR-NOT-AUTHORIZED)
     SUCCESS
   )
 )
@@ -121,16 +120,10 @@
   )
 )
 
-(define-private (decode-pyth (pyth-record 
-  {conf: uint, ema-conf: uint, ema-price: int, expo: int, prev-publish-time: uint, price: int, publish-time: uint}
-) (max-confidence-ratio uint)) 
-  (let 
+(define-private (decode-lazer (price int) (expo int) (publish-time-us uint) (confidence (optional uint)) (max-confidence-ratio uint))
+  (let
     (
-      (timestamp (get publish-time pyth-record))
-      (expo (get expo pyth-record))
-      (price (get price pyth-record))
-      (price-conf (get conf pyth-record))
-      
+      (timestamp (/ publish-time-us MICROS_PER_SECOND))
     )
     (asserts! (> price 0) ERR-INVALID-PRICE)
     ;; Upper bound 11 is the max safe value: pyth_max_int64 (~9.2e18)
@@ -139,15 +132,13 @@
     ;; below the overflow threshold for any valid Pyth price.
     (asserts! (and (>= expo -18) (<= expo 11)) ERR-INVALID-EXPONENT)
     (asserts! (is-valid timestamp) ERR-PYTH-PRICE-STALE)
-    (try! (check-confidence (to-uint price) price-conf max-confidence-ratio))
+    ;; Lazer confidence is optional; enforce the bound only when present (v1 always provides it).
+    (asserts! (match confidence conf (confidence-ok (to-uint price) conf max-confidence-ratio) true) ERR-PRICE-CONFIDENCE-LOW)
     (ok (to-uint (convert-res price expo PRICE_DECIMALS)))
 ))
 
-(define-private (check-confidence (price uint) (confidence uint) (max-confidence-ratio uint))
-  (if (<= confidence (/ (* price max-confidence-ratio) CONFIDENCE_SCALING_FACTOR))
-    (ok true)
-    ERR-PRICE-CONFIDENCE-LOW
-  )
+(define-private (confidence-ok (price uint) (confidence uint) (max-confidence-ratio uint))
+  (<= confidence (/ (* price max-confidence-ratio) CONFIDENCE_SCALING_FACTOR))
 )
 
 (define-private (is-valid (timestamp uint))
@@ -166,8 +157,8 @@
   (if (>= expo 0)
     (* price (pow 10 (+ expo resolution-digits)))
     (let ((diff (- resolution-digits (abs expo))))
-      (if (is-eq diff 0) 
-        price 
+      (if (is-eq diff 0)
+        price
         (if (> diff 0) (* price (pow 10 diff)) (/ price (pow 10 (abs diff))))
     ))
 ))

--- a/contracts/test/borrower-proxy.clar
+++ b/contracts/test/borrower-proxy.clar
@@ -1,13 +1,13 @@
 (use-trait token-trait .trait-sip-010.sip-010-trait)
 
-(define-public (borrow (pyth-price-feed-data (optional (buff 8192))) (amount uint))
-    (contract-call? .borrower-v1 borrow pyth-price-feed-data amount (some tx-sender))
+(define-public (borrow (amount uint))
+    (contract-call? .borrower-v1 borrow amount (some tx-sender))
 )
 
 (define-public (add-collateral (collateral <token-trait>) (amount uint))
     (contract-call? .borrower-v1 add-collateral collateral amount (some tx-sender))
 )
 
-(define-public (remove-collateral (pyth-price-feed-data (optional (buff 8192))) (collateral <token-trait>) (amount uint))
-    (contract-call? .borrower-v1 remove-collateral pyth-price-feed-data collateral amount (some tx-sender))
+(define-public (remove-collateral (collateral <token-trait>) (amount uint))
+    (contract-call? .borrower-v1 remove-collateral collateral amount (some tx-sender))
 )

--- a/contracts/test/mock-liquidator-with-flash-loan.clar
+++ b/contracts/test/mock-liquidator-with-flash-loan.clar
@@ -7,7 +7,6 @@
 (define-constant ERR-NO-STORAGE (err u60001))
 
 (define-data-var liquidator-data (optional {
-  pyth-price-feed-data: (optional (buff 8192)),
   repay-amount: uint,
   min-collateral-expected: uint,
   user: principal
@@ -17,19 +16,17 @@
 (define-public (on-granite-flash-loan (amount uint) (fee uint) (data (optional (buff 20480))))
   (let (
       (ldata (unwrap! (var-get liquidator-data) ERR-NO-STORAGE))
-      (pyth-price-feed (get pyth-price-feed-data ldata))
       (user (get user ldata))
       (repay-amount (get repay-amount ldata))
       (min-collateral-expected (get min-collateral-expected ldata))
     )
-    (try! (contract-call? .liquidator-v1 liquidate-collateral pyth-price-feed .mock-btc user repay-amount min-collateral-expected))
+    (try! (contract-call? .liquidator-v1 liquidate-collateral .mock-btc user repay-amount min-collateral-expected))
     (ok true)
   )
 )
 
 
-(define-public (liquidate-collateral 
-  (pyth-price-feed-data (optional (buff 8192)))
+(define-public (liquidate-collateral
   (user principal)
   (liquidator-repay-amount uint)
   (min-collateral-expected uint)
@@ -37,7 +34,6 @@
 )
   (begin
     (var-set liquidator-data (some {
-      pyth-price-feed-data: pyth-price-feed-data,
       repay-amount: liquidator-repay-amount,
       min-collateral-expected: min-collateral-expected,
       user: user,

--- a/contracts/test/mock-oracle.clar
+++ b/contracts/test/mock-oracle.clar
@@ -37,14 +37,9 @@
 )
 
 (define-public (set-price (ticker principal) (new-price uint))
-  (begin 
+  (begin
     (unwrap! (map-get? price-feeds ticker) ERR-TOKEN-NOT-ADDED)
     (map-set price-feeds ticker new-price)
     SUCCESS
   )
-)
-
-(define-public (update-pyth (maybe-vaa-buffer (optional (buff 8192))))
-  ;; testing oracle with no price verification
-  (match maybe-vaa-buffer vaa-buffer (if (< u1 (len vaa-buffer)) ERR-INVALID-BUFFER SUCCESS) SUCCESS)
 )

--- a/contracts/test/pyth-lazer-storage.clar
+++ b/contracts/test/pyth-lazer-storage.clar
@@ -1,0 +1,42 @@
+;; SPDX-License-Identifier: BUSL-1.1
+;; Test double for Hiro's pyth-lazer-storage. Exposes the production READ interface
+;; (get-price returning the real record shape) plus a public setter so tests seed
+;; prices at runtime. Simnet only: mainnet references Hiro's deployed contract.
+
+(define-constant ERR_PRICE_FEED_NOT_FOUND (err u3003))
+
+(define-map prices uint {
+  price: int,
+  exponent: int,
+  publisher-count: uint,
+  confidence: (optional uint),
+  best-bid: (optional int),
+  best-ask: (optional int),
+  ema-price: (optional int),
+  ema-confidence: (optional uint),
+  feed-update-timestamp: (optional uint),
+  publish-time: uint,
+  channel: uint,
+})
+
+(define-read-only (get-price (feed-id uint))
+  (ok (unwrap! (map-get? prices feed-id) ERR_PRICE_FEED_NOT_FOUND)))
+
+;; Seed a feed's price at runtime. The record fields the adapter does not read
+;; default to none / u1.
+(define-public (set-price (feed-id uint) (price int) (exponent int) (publish-time uint) (confidence (optional uint)))
+  (begin
+    (map-set prices feed-id {
+      price: price,
+      exponent: exponent,
+      publisher-count: u1,
+      confidence: confidence,
+      best-bid: none,
+      best-ask: none,
+      ema-price: none,
+      ema-confidence: none,
+      feed-update-timestamp: none,
+      publish-time: publish-time,
+      channel: u1,
+    })
+    (ok true)))

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -7,43 +7,33 @@ genesis:
     - name: deployer
       address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: faucet
       address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_1
       address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_2
       address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_3
       address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_4
       address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_5
       address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_6
       address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_7
       address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
     - name: wallet_8
       address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
       balance: "100000000000000"
-      sbtc-balance: "1000000000"
   contracts:
     - costs
     - pox
@@ -95,39 +85,9 @@ plan:
             path: contracts/modules/linear-kinked-ir-v1.clar
             clarity-version: 3
         - emulated-contract-publish:
-            contract-name: wormhole-traits-v2
+            contract-name: pyth-lazer-storage
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/pyth/contracts/wormhole/wormhole-traits-v2.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: pyth-traits-v2
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/pyth/contracts/pyth-traits-v2.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: pyth-governance-v3
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/pyth/contracts/pyth-governance-v3.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: pyth-oracle-v4
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/pyth/contracts/pyth-oracle-v4.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: pyth-pnau-decoder-v3
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/pyth/contracts/pyth-pnau-decoder-v3.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: pyth-storage-v4
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/pyth/contracts/pyth-storage-v4.clar
-            clarity-version: 3
-        - emulated-contract-publish:
-            contract-name: wormhole-core-v4
-            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            path: contracts/pyth/contracts/wormhole/wormhole-core-v4.clar
+            path: contracts/test/pyth-lazer-storage.clar
             clarity-version: 3
         - emulated-contract-publish:
             contract-name: pyth-adapter-v1
@@ -184,9 +144,6 @@ plan:
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/flash-loan-v1.clar
             clarity-version: 3
-      epoch: "3.0"
-    - id: 1
-      transactions:
         - emulated-contract-publish:
             contract-name: meta-governance-v1
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
@@ -217,6 +174,9 @@ plan:
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/lp-incentives-v2.clar
             clarity-version: 3
+      epoch: "3.0"
+    - id: 1
+      transactions:
         - emulated-contract-publish:
             contract-name: mock-flash-loan-callback
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM

--- a/tests/borrower.test.ts
+++ b/tests/borrower.test.ts
@@ -86,7 +86,7 @@ describe("borrower tests", () => {
     const borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(70000000000), Cl.none()],
+      [Cl.uint(70000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -95,7 +95,6 @@ describe("borrower tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(50000000000n),
         Cl.none(),
@@ -141,7 +140,6 @@ describe("borrower tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(10000000001n),
         Cl.none(),
@@ -284,7 +282,7 @@ describe("borrower tests", () => {
     let borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(100000000000), Cl.none()],
+      [Cl.uint(100000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeErr(Cl.uint(20002));
@@ -294,7 +292,7 @@ describe("borrower tests", () => {
     borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000), Cl.none()],
+      [Cl.uint(10000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -334,7 +332,7 @@ describe("borrower tests", () => {
     let borrow = simnet.callPublicFn(
       "borrower-proxy",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000)],
+      [Cl.uint(10000000000)],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -381,7 +379,6 @@ describe("borrower tests", () => {
       "borrower-proxy",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(90000000000),
       ],
@@ -411,7 +408,6 @@ describe("borrower tests", () => {
       "borrower-proxy",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(10000000000),
       ],
@@ -455,7 +451,7 @@ describe("borrower tests", () => {
     const borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000), Cl.none()],
+      [Cl.uint(10000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -488,7 +484,7 @@ describe("borrower tests", () => {
     const borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(1000000000), Cl.none()],
+      [Cl.uint(1000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -520,7 +516,7 @@ describe("borrower tests", () => {
     let borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(11000000000), Cl.none()],
+      [Cl.uint(11000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeErr(Cl.uint(20001));
@@ -587,7 +583,7 @@ describe("borrower tests", () => {
     const borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000), Cl.none()],
+      [Cl.uint(10000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -689,7 +685,7 @@ describe("borrower tests", () => {
     const borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000), Cl.none()],
+      [Cl.uint(10000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -765,7 +761,7 @@ describe("borrower tests", () => {
     const borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000), Cl.none()],
+      [Cl.uint(10000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -864,7 +860,7 @@ describe("borrower tests", () => {
     const borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(0.99999991e8), Cl.none()],
+      [Cl.uint(0.99999991e8), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeErr(Cl.uint(20001));
@@ -949,7 +945,7 @@ describe("borrower tests", () => {
       simnet.callPublicFn(
         "borrower-v1",
         "borrow",
-        [Cl.none(), Cl.uint(100000000000), Cl.none()],
+        [Cl.uint(100000000000), Cl.none()],
         borrower1
       );
     } catch (err) {}
@@ -973,7 +969,7 @@ describe("borrower tests", () => {
     let borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(2418649660), Cl.none()],
+      [Cl.uint(2418649660), Cl.none()],
       borrower1
     );
 
@@ -1042,7 +1038,7 @@ describe("borrower tests", () => {
     let borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(2418649660), Cl.none()],
+      [Cl.uint(2418649660), Cl.none()],
       borrower1
     );
 
@@ -1126,7 +1122,7 @@ describe("borrower tests", () => {
       let borrowResult = simnet.callPublicFn(
         "borrower-v1",
         "borrow",
-        [Cl.none(), Cl.uint(1), Cl.none()],
+        [Cl.uint(1), Cl.none()],
         borrower1
       ); // Borrow the 1 wei
       expect(borrowResult.result).toBeOk(Cl.bool(true));
@@ -1344,7 +1340,6 @@ describe("M-01 interest-dust no-stakers regression", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18_181_818_181),
@@ -1406,7 +1401,6 @@ describe("M-01 interest-dust no-stakers regression", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18_181_818_181),

--- a/tests/borrower_flow.test.ts
+++ b/tests/borrower_flow.test.ts
@@ -85,7 +85,6 @@ describe("Borrower User flow tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(40),
         Cl.none(),
@@ -98,7 +97,6 @@ describe("Borrower User flow tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.uint(490),
         Cl.none(),
@@ -132,7 +130,6 @@ describe("Borrower User flow tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(60),
         Cl.none(),
@@ -145,7 +142,6 @@ describe("Borrower User flow tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.uint(1000),
         Cl.none(),
@@ -216,7 +212,6 @@ describe("Borrower User flow tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1386),
@@ -258,7 +253,6 @@ describe("Borrower User flow tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(100),
         Cl.none(),
@@ -271,7 +265,6 @@ describe("Borrower User flow tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.uint(744),
         Cl.none(),
@@ -416,7 +409,6 @@ describe("Borrower User flow tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -468,7 +460,6 @@ describe("Borrower User flow tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.principal(borrower1),
         Cl.uint(1000),

--- a/tests/governance.test.ts
+++ b/tests/governance.test.ts
@@ -880,9 +880,7 @@ describe("governance tests", () => {
   it("governance can update pyth price feeds", async () => {
     state_set_governance_contract(deployer);
 
-    const priceIdentifier = Cl.bufferFromHex(
-      "b0948a5e5313200c632b51bb5ca32f6de0d36e9950a942d19751e833f70dabfd"
-    );
+    const priceIdentifier = Cl.uint(3);
     let response = simnet.callPublicFn(
       "governance-v1",
       "initiate-proposal-to-update-pyth-feed",
@@ -899,7 +897,7 @@ describe("governance tests", () => {
     // the mock-usdc principal.
     expect(response.result).toBeOk(
       Cl.bufferFromHex(
-        "8a12529c357ba3d294fd399cb799125badb2b1864e37c9aab31a6bd48f280f14"
+        "12f5697a42933bc9f777d6d6c367aebd24c187a9c535f33268193d7923c823c1"
       )
     );
   });
@@ -913,9 +911,7 @@ describe("governance tests", () => {
   it("M-02 timelock: pyth feed update cannot execute in the same block", async () => {
     state_set_governance_contract(deployer);
 
-    const priceIdentifier = Cl.bufferFromHex(
-      "b0948a5e5313200c632b51bb5ca32f6de0d36e9950a942d19751e833f70dabfd"
-    );
+    const priceIdentifier = Cl.uint(999);
     const usdcPrincipal = Cl.contractPrincipal(deployer, "mock-usdc");
 
     // Snapshot the pre-update price-feed entry to verify behavioral change.
@@ -1019,9 +1015,7 @@ describe("governance tests", () => {
   it("M-02 hash-includes-token: distinct tokens with same feed produce distinct proposal-ids", async () => {
     state_set_governance_contract(deployer);
 
-    const sameFeed = Cl.bufferFromHex(
-      "b0948a5e5313200c632b51bb5ca32f6de0d36e9950a942d19751e833f70dabfd"
-    );
+    const sameFeed = Cl.uint(3);
     const sameMaxConfidence = Cl.uint(100);
     const sameExpiresIn = Cl.uint(10);
 

--- a/tests/governance.test.ts
+++ b/tests/governance.test.ts
@@ -189,7 +189,6 @@ describe("governance tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(1),
         Cl.none(),
@@ -2080,7 +2079,7 @@ describe("governance tests", () => {
     let borrow = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000), Cl.none()],
+      [Cl.uint(10000000000), Cl.none()],
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
@@ -2128,7 +2127,6 @@ describe("governance tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(10000000000),
         Cl.none(),
@@ -2161,7 +2159,6 @@ describe("governance tests", () => {
       "borrower-v1",
       "remove-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.uint(20000000000),
         Cl.none(),

--- a/tests/liquidation.test.ts
+++ b/tests/liquidation.test.ts
@@ -376,7 +376,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18181818181),
@@ -465,7 +464,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(0),
@@ -515,7 +513,7 @@ describe("liquidation tests", () => {
       tx.callPublicFn(
         "borrower-v1",
         "borrow",
-        [Cl.none(), Cl.uint(18000000000), Cl.none()],
+        [Cl.uint(18000000000), Cl.none()],
         borrower1
       ),
       // make position insolvant
@@ -543,7 +541,6 @@ describe("liquidation tests", () => {
         "liquidator-v1",
         "liquidate-collateral",
         [
-          Cl.none(),
           btc_collateral_contract,
           Cl.principal(borrower1),
           Cl.uint(18181818181),
@@ -636,7 +633,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(17777777777),
@@ -650,7 +646,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(17777777777),
@@ -688,7 +683,7 @@ describe("liquidation tests", () => {
     simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(10000000000), Cl.none()],
+      [Cl.uint(10000000000), Cl.none()],
       borrower1
     );
 
@@ -769,7 +764,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18181818181),
@@ -852,7 +846,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(39000013190),
@@ -989,7 +982,7 @@ describe("liquidation tests", () => {
     let liquidate = simnet.callPublicFn(
       "liquidator-v1",
       "batch-liquidate",
-      [Cl.none(), btc_collateral_contract, Cl.list(batchData)],
+      [btc_collateral_contract, Cl.list(batchData)],
       depositor
     );
     expect(liquidate.result).toBeOk(Cl.bool(true));
@@ -1021,7 +1014,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(0),
@@ -1090,7 +1082,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         contractPrincipalCV(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(2500000000000),
@@ -1166,7 +1157,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18181818181),
@@ -1243,7 +1233,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18181818181),
@@ -1319,7 +1308,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18181818181),
@@ -1395,7 +1383,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(18181818181),
@@ -1512,7 +1499,6 @@ describe("liquidation tests", () => {
       "mock-liquidator-with-flash-loan",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.principal(borrower1),
         Cl.uint(repayAmount),
         Cl.uint(1),
@@ -1580,7 +1566,6 @@ describe("liquidation tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral_contract,
         Cl.principal(borrower1),
         Cl.uint(0),

--- a/tests/modules/pyth-adapter.test.ts
+++ b/tests/modules/pyth-adapter.test.ts
@@ -1,20 +1,16 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { Cl, ClarityType } from "@stacks/transactions";
-import {
-  init_pyth,
-  set_pyth_time_delta,
-  guardianSet,
-  get_token_feed,
-} from "../pyth";
-import { pyth } from "../../contracts/pyth/unit-tests/pyth/helpers";
-import { wormhole } from "../../contracts/pyth/unit-tests/wormhole/helpers";
+import { init_pyth, set_pyth_time_delta, get_token_feed, set_price_at } from "../pyth";
 
 const accounts = simnet.getAccounts();
 const deployer = accounts.get("deployer")!;
 const address1 = accounts.get("wallet_1")!;
 
+// Lazer publish-time is microseconds; the adapter divides by this for seconds.
+const MICROS_PER_SECOND = 1_000_000n;
+
 /**
- * Returns the current simnet block time.
+ * Returns the current simnet block time (seconds).
  */
 const getSimnetBlockTime = (): bigint => {
   const r = simnet.callReadOnlyFn(
@@ -27,8 +23,7 @@ const getSimnetBlockTime = (): bigint => {
 };
 
 /**
- * Helper to submit a raw price update to pyth storage with custom price/expo values.
- * Uses simnet-aligned timestamps.
+ * Seeds a raw price into the storage mock at the current simnet block time.
  */
 const set_raw_price = async (
   token: string,
@@ -37,45 +32,14 @@ const set_raw_price = async (
   conf?: bigint
 ): Promise<bigint> => {
   const feed = get_token_feed(token);
-  const publishTime = getSimnetBlockTime();
-  let actualPricesUpdates = pyth.buildPriceUpdateBatch([
-    [feed, { price, expo, publishTime, conf }],
-  ]);
-  let actualPricesUpdatesVaaPayload =
-    pyth.buildAuwvVaaPayload(actualPricesUpdates);
-  let payload = pyth.serializeAuwvVaaPayloadToBuffer(
-    actualPricesUpdatesVaaPayload
-  );
-  let vaaBody = wormhole.buildValidVaaBodySpecs({
-    payload,
-    emitter: pyth.DefaultPricesDataSources[0],
-  });
-  let vaaHeader = wormhole.buildValidVaaHeader(guardianSet, vaaBody, {
-    version: 1,
-    guardianSetId: 1,
-  });
-  let vaa = wormhole.serializeVaaToBuffer(vaaHeader, vaaBody);
-  let pnauHeader = pyth.buildPnauHeader();
-  let pricesUpdatesToSubmit = [feed];
-  let pnau = pyth.serializePnauToBuffer(pnauHeader, {
-    vaa,
-    pricesUpdates: actualPricesUpdates,
-    pricesUpdatesToSubmit,
-  });
-
-  const res = simnet.callPublicFn(
-    "pyth-adapter-v1",
-    "update-pyth",
-    [Cl.some(Cl.buffer(pnau))],
-    deployer
-  );
-  expect(res.result).toHaveClarityType(ClarityType.ResponseOk);
-
-  return publishTime;
+  const publishTimeMicros = getSimnetBlockTime() * MICROS_PER_SECOND;
+  set_price_at(feed, price, expo, publishTimeMicros, deployer, conf ?? 0n);
+  return publishTimeMicros / MICROS_PER_SECOND;
 };
 
 /**
- * Helper to submit a price update with a custom publish time.
+ * Seeds a price at a caller-supplied publish time. The value is SECONDS
+ * (tests pass second-scale values like blockTime+3600); stored as microseconds.
  */
 const set_price_with_time = async (
   token: string,
@@ -84,38 +48,7 @@ const set_price_with_time = async (
   expo: number = -8
 ): Promise<void> => {
   const feed = get_token_feed(token);
-  let actualPricesUpdates = pyth.buildPriceUpdateBatch([
-    [feed, { price, expo, publishTime }],
-  ]);
-  let actualPricesUpdatesVaaPayload =
-    pyth.buildAuwvVaaPayload(actualPricesUpdates);
-  let payload = pyth.serializeAuwvVaaPayloadToBuffer(
-    actualPricesUpdatesVaaPayload
-  );
-  let vaaBody = wormhole.buildValidVaaBodySpecs({
-    payload,
-    emitter: pyth.DefaultPricesDataSources[0],
-  });
-  let vaaHeader = wormhole.buildValidVaaHeader(guardianSet, vaaBody, {
-    version: 1,
-    guardianSetId: 1,
-  });
-  let vaa = wormhole.serializeVaaToBuffer(vaaHeader, vaaBody);
-  let pnauHeader = pyth.buildPnauHeader();
-  let pricesUpdatesToSubmit = [feed];
-  let pnau = pyth.serializePnauToBuffer(pnauHeader, {
-    vaa,
-    pricesUpdates: actualPricesUpdates,
-    pricesUpdatesToSubmit,
-  });
-
-  const res = simnet.callPublicFn(
-    "pyth-adapter-v1",
-    "update-pyth",
-    [Cl.some(Cl.buffer(pnau))],
-    deployer
-  );
-  expect(res.result).toHaveClarityType(ClarityType.ResponseOk);
+  set_price_at(feed, price, expo, publishTime * MICROS_PER_SECOND, deployer);
 };
 
 describe("pyth-adapter-v1 oracle hardening tests", () => {
@@ -130,7 +63,7 @@ describe("pyth-adapter-v1 oracle hardening tests", () => {
       "update-price-feed-id",
       [
         Cl.contractPrincipal(deployer, "mock-btc"),
-        Cl.buffer(feed),
+        Cl.uint(feed),
         Cl.uint(500),
       ],
       deployer

--- a/tests/modules/withdrawal-caps.test.ts
+++ b/tests/modules/withdrawal-caps.test.ts
@@ -205,7 +205,7 @@ describe("withdrawal caps tests", () => {
     res = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(410_000_000_00), Cl.none()],
+      [Cl.uint(410_000_000_00), Cl.none()],
       borrower
     );
     expect(res.result).toBeErr(Cl.uint(120003));
@@ -214,7 +214,7 @@ describe("withdrawal caps tests", () => {
     res = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(150_000_000_00), Cl.none()],
+      [Cl.uint(150_000_000_00), Cl.none()],
       borrower
     );
     expect(res.result).toBeOk(Cl.bool(true));
@@ -232,7 +232,7 @@ describe("withdrawal caps tests", () => {
     res = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(200_000_000_00), Cl.none()],
+      [Cl.uint(200_000_000_00), Cl.none()],
       borrower
     );
     expect(res.result).toBeOk(Cl.bool(true));
@@ -250,7 +250,7 @@ describe("withdrawal caps tests", () => {
     res = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(51_000_000_00), Cl.none()],
+      [Cl.uint(51_000_000_00), Cl.none()],
       borrower
     );
     expect(res.result).toBeErr(Cl.uint(120003));
@@ -264,7 +264,7 @@ describe("withdrawal caps tests", () => {
     res = simnet.callPublicFn(
       "borrower-v1",
       "borrow",
-      [Cl.none(), Cl.uint(51_000_000_00), Cl.none()],
+      [Cl.uint(51_000_000_00), Cl.none()],
       borrower
     );
 
@@ -334,7 +334,7 @@ describe("withdrawal caps tests", () => {
     let resp = simnet.callPublicFn(
       "borrower-v1",
       "remove-collateral",
-      [Cl.none(), btcCV, Cl.uint(700_000_000_0), Cl.none()],
+      [btcCV, Cl.uint(700_000_000_0), Cl.none()],
       depositor
     ).result;
     expect(resp).toBeErr(Cl.uint(120004));
@@ -343,7 +343,7 @@ describe("withdrawal caps tests", () => {
     resp = simnet.callPublicFn(
       "borrower-v1",
       "remove-collateral",
-      [Cl.none(), btcCV, Cl.uint(500_000_000_0), Cl.none()],
+      [btcCV, Cl.uint(500_000_000_0), Cl.none()],
       depositor
     ).result;
     expect(resp).toBeOk(Cl.bool(true));
@@ -360,7 +360,7 @@ describe("withdrawal caps tests", () => {
     resp = simnet.callPublicFn(
       "borrower-v1",
       "remove-collateral",
-      [Cl.none(), btcCV, Cl.uint(100_000_000_0), Cl.none()],
+      [btcCV, Cl.uint(100_000_000_0), Cl.none()],
       depositor
     ).result;
     expect(resp).toBeOk(Cl.bool(true));
@@ -377,7 +377,7 @@ describe("withdrawal caps tests", () => {
     resp = simnet.callPublicFn(
       "borrower-v1",
       "remove-collateral",
-      [Cl.none(), btcCV, Cl.uint(41_000_000_0), Cl.none()],
+      [btcCV, Cl.uint(41_000_000_0), Cl.none()],
       depositor
     ).result;
     expect(resp).toBeErr(Cl.uint(120004));
@@ -391,7 +391,7 @@ describe("withdrawal caps tests", () => {
     resp = simnet.callPublicFn(
       "borrower-v1",
       "remove-collateral",
-      [Cl.none(), btcCV, Cl.uint(41_000_000_0), Cl.none()],
+      [btcCV, Cl.uint(41_000_000_0), Cl.none()],
       depositor
     ).result;
     expect(resp).toBeOk(Cl.bool(true));

--- a/tests/poc-em01-repay-roundup-underflow.test.ts
+++ b/tests/poc-em01-repay-roundup-underflow.test.ts
@@ -135,7 +135,7 @@ describe("PoC E-M-01: integer-floor repay-allowed > debt underflow", () => {
     const result = simnet.callPublicFn(
       "liquidator-v1",
       "liquidate-collateral",
-      [Cl.none(), btc_collateral, Cl.principal(borrower), Cl.uint(1_000_000), Cl.uint(1)],
+      [btc_collateral, Cl.principal(borrower), Cl.uint(1_000_000), Cl.uint(1)],
       liquidator,
     );
     console.log(`[B] liquidate result type=${result.result.type} value=${JSON.stringify(result.result.value)}`);

--- a/tests/poc-em02-socialize-baddebt-divzero.test.ts
+++ b/tests/poc-em02-socialize-baddebt-divzero.test.ts
@@ -89,7 +89,7 @@ describe("PoC E-M-02: socialize-bad-debt DivisionByZero on full-payoff bad-debt 
     const result = simnet.callPublicFn(
       "liquidator-v1",
       "liquidate-collateral",
-      [Cl.none(), btc_collateral, Cl.principal(borrower), Cl.uint(1_000_000), Cl.uint(1)],
+      [btc_collateral, Cl.principal(borrower), Cl.uint(1_000_000), Cl.uint(1)],
       liquidator,
     );
     console.log(`[E-M-02] liquidate result type=${result.result.type} value=${JSON.stringify(result.result.value)}`);

--- a/tests/poc-liquidation-market-asset-price.test.ts
+++ b/tests/poc-liquidation-market-asset-price.test.ts
@@ -129,7 +129,6 @@ function callLiquidate(
     "liquidator-v1",
     "liquidate-collateral",
     [
-      Cl.none(),
       btc_collateral,
       Cl.principal(borrower),
       Cl.uint(liquidatorRepayAmount),
@@ -444,7 +443,6 @@ describe("PoC: liquidator-v1 USD-value vs raw-token denomination", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         btc_collateral,
         Cl.principal(borrower),
         Cl.uint(LIQUIDATOR_REPAY_INPUT),

--- a/tests/poc-slash-underflow.test.ts
+++ b/tests/poc-slash-underflow.test.ts
@@ -192,7 +192,7 @@ describe("PoC: slash-total-staked-lp-tokens underflow", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),                   // pyth price feed data
+        // pyth price feed data
         btc,                         // collateral token
         Cl.principal(borrower1),     // user to liquidate
         Cl.uint(20_000_000_000),     // liquidator-repay-amount

--- a/tests/pyth.ts
+++ b/tests/pyth.ts
@@ -1,21 +1,18 @@
 import { expect } from "vitest";
 import { Cl, ClarityType } from "@stacks/transactions";
-import { pyth } from "../contracts/pyth/unit-tests/pyth/helpers";
-import { wormhole } from "../contracts/pyth/unit-tests/wormhole/helpers";
 import { scalingFactor } from "./utils";
 
-export const pythDecoderPnauContractName = "pyth-pnau-decoder-v3";
-export const pythGovernanceContractName = "pyth-governance-v3";
-export const pythStorageContractName = "pyth-storage-v4";
-export const wormholeCoreContractName = "wormhole-core-v4";
-export const guardianSet = wormhole.generateGuardianSetKeychain(19);
+// Lazer publish-time is microseconds; the adapter divides by this for its
+// seconds-based staleness. Tests write publish-time = T * MICROS_PER_SECOND.
+const MICROS_PER_SECOND = 1_000_000n;
 
-// Monotonically increasing publish time counter to ensure unique timestamps
+// Monotonically increasing publish time (microseconds) so a later seed always
+// reads as fresher than an earlier one.
 let lastPublishTime = 0n;
 
 /**
  * Returns the current simnet block time by reading the faucet helper.
- * This is aligned with the simnet's internal clock, not wall-clock time.
+ * Aligned with the simnet's internal clock, not wall-clock time.
  */
 const getSimnetBlockTime = (): bigint => {
   const r = simnet.callReadOnlyFn(
@@ -27,48 +24,22 @@ const getSimnetBlockTime = (): bigint => {
   return r.result.value as bigint;
 };
 
-export const init_pyth = (sender: any) => {
+export const init_pyth = (_sender: any) => {
   lastPublishTime = 0n;
-
-  wormhole.applyGuardianSetUpdate(
-    guardianSet,
-    1,
-    sender,
-    wormholeCoreContractName
-  );
-
-  pyth.applyGovernanceDataSourceUpdate(
-    pyth.DefaultGovernanceDataSourceUpdate,
-    pyth.InitialGovernanceDataSource,
-    guardianSet,
-    sender,
-    pythGovernanceContractName,
-    wormholeCoreContractName,
-    2n
-  );
-
-  pyth.applyPricesDataSourceUpdate(
-    pyth.DefaultPricesDataSources,
-    pyth.DefaultGovernanceDataSource,
-    guardianSet,
-    sender,
-    pythGovernanceContractName,
-    wormholeCoreContractName,
-    3n
-  );
 };
 
-export const get_token_feed = (token: string) => {
-  if (token.includes("btc")) return pyth.BtcPriceIdentifier;
-  else if (token.includes("eth")) return pyth.StxPriceIdentifier;
-  else if (token.includes("usdc")) return pyth.UsdcPriceIdentifier;
+export const get_token_feed = (token: string): bigint => {
+  // Placeholder Lazer numeric feed ids; the real catalog ids come from Hiro at bake time.
+  if (token.includes("btc")) return 1n;
+  else if (token.includes("eth")) return 2n;
+  else if (token.includes("usdc")) return 3n;
   else throw "invalid token feed";
 };
 
 export const get_token_min_confidence_ratio = (token: string) => {
   if (token.includes("btc")) return 500; // 5%
-  else if (token.includes("eth")) return 500; // 5%;
-  else if (token.includes("usdc")) return 100; // 1 %;
+  else if (token.includes("eth")) return 500; // 5%
+  else if (token.includes("usdc")) return 100; // 1%
   else throw "invalid token feed";
 };
 
@@ -82,11 +53,7 @@ export const set_initial_price = async (
   const res = simnet.callPublicFn(
     "pyth-adapter-v1",
     "update-price-feed-id",
-    [
-      Cl.contractPrincipal(deployer, token),
-      Cl.buffer(feed),
-      Cl.uint(minConfidenceRatio),
-    ],
+    [Cl.contractPrincipal(deployer, token), Cl.uint(feed), Cl.uint(minConfidenceRatio)],
     deployer
   );
   expect(res.result).toHaveClarityType(ClarityType.ResponseOk);
@@ -105,14 +72,44 @@ export const set_pyth_time_delta = async (delta: number, deployer: any) => {
 };
 
 /**
- * Returns a publish time aligned with simnet block time.
- * Ensures monotonically increasing timestamps for pyth updates.
+ * Publish time (microseconds) aligned with simnet block time, kept strictly
+ * monotonic across seeds.
  */
-const getPublishTime = (): bigint => {
-  const blockTime = getSimnetBlockTime();
-  const publishTime = blockTime > lastPublishTime ? blockTime : lastPublishTime + 1n;
+const getPublishTimeMicros = (): bigint => {
+  const blockTimeMicros = getSimnetBlockTime() * MICROS_PER_SECOND;
+  const publishTime =
+    blockTimeMicros > lastPublishTime ? blockTimeMicros : lastPublishTime + 1n;
   lastPublishTime = publishTime;
   return publishTime;
+};
+
+/**
+ * Seeds a feed's price via the storage mock's public setter (the production read
+ * path is `get-price`; this is the test-only way to populate it). Returns the
+ * publish-time in SECONDS.
+ */
+export const set_price_at = (
+  feed: bigint,
+  price: bigint,
+  expo: number,
+  publishTimeMicros: bigint,
+  deployer: any,
+  conf: bigint = 0n
+): bigint => {
+  const res = simnet.callPublicFn(
+    "pyth-lazer-storage",
+    "set-price",
+    [
+      Cl.uint(feed),
+      Cl.int(price),
+      Cl.int(expo),
+      Cl.uint(publishTimeMicros),
+      Cl.some(Cl.uint(conf)),
+    ],
+    deployer
+  );
+  expect(res.result).toBeOk(Cl.bool(true));
+  return publishTimeMicros / MICROS_PER_SECOND;
 };
 
 export const set_price = async (
@@ -123,44 +120,7 @@ export const set_price = async (
   prevPublishTime?: bigint
 ): Promise<bigint> => {
   const feed = get_token_feed(token);
-  const publishTime = getPublishTime();
-  let actualPricesUpdates = pyth.buildPriceUpdateBatch([
-    [
-      feed,
-      { price: price * scalingFactor, expo, publishTime, prevPublishTime },
-    ],
-  ]);
-  let actualPricesUpdatesVaaPayload =
-    pyth.buildAuwvVaaPayload(actualPricesUpdates);
-  let payload = pyth.serializeAuwvVaaPayloadToBuffer(
-    actualPricesUpdatesVaaPayload
-  );
-  let vaaBody = wormhole.buildValidVaaBodySpecs({
-    payload,
-    emitter: pyth.DefaultPricesDataSources[0],
-  });
-  let vaaHeader = wormhole.buildValidVaaHeader(guardianSet, vaaBody, {
-    version: 1,
-    guardianSetId: 1,
-  });
-  let vaa = wormhole.serializeVaaToBuffer(vaaHeader, vaaBody);
-  let pnauHeader = pyth.buildPnauHeader();
-  let pricesUpdatesToSubmit = [feed];
-  let pnau = pyth.serializePnauToBuffer(pnauHeader, {
-    vaa,
-    pricesUpdates: actualPricesUpdates,
-    pricesUpdatesToSubmit,
-  });
-
-  const res = simnet.callPublicFn(
-    "pyth-adapter-v1",
-    "update-pyth",
-    [Cl.some(Cl.buffer(pnau))],
-    deployer
-  );
-  expect(res.result).toHaveClarityType(ClarityType.ResponseOk);
-
-  return publishTime;
+  return set_price_at(feed, price * scalingFactor, expo, getPublishTimeMicros(), deployer);
 };
 
 export const set_price_without_scaling = async (
@@ -171,39 +131,5 @@ export const set_price_without_scaling = async (
   prevPublishTime?: bigint
 ): Promise<bigint> => {
   const feed = get_token_feed(token);
-  const publishTime = getPublishTime();
-  let actualPricesUpdates = pyth.buildPriceUpdateBatch([
-    [feed, { price: price, expo, publishTime, prevPublishTime }],
-  ]);
-  let actualPricesUpdatesVaaPayload =
-    pyth.buildAuwvVaaPayload(actualPricesUpdates);
-  let payload = pyth.serializeAuwvVaaPayloadToBuffer(
-    actualPricesUpdatesVaaPayload
-  );
-  let vaaBody = wormhole.buildValidVaaBodySpecs({
-    payload,
-    emitter: pyth.DefaultPricesDataSources[0],
-  });
-  let vaaHeader = wormhole.buildValidVaaHeader(guardianSet, vaaBody, {
-    version: 1,
-    guardianSetId: 1,
-  });
-  let vaa = wormhole.serializeVaaToBuffer(vaaHeader, vaaBody);
-  let pnauHeader = pyth.buildPnauHeader();
-  let pricesUpdatesToSubmit = [feed];
-  let pnau = pyth.serializePnauToBuffer(pnauHeader, {
-    vaa,
-    pricesUpdates: actualPricesUpdates,
-    pricesUpdatesToSubmit,
-  });
-
-  const res = simnet.callPublicFn(
-    "pyth-adapter-v1",
-    "update-pyth",
-    [Cl.some(Cl.buffer(pnau))],
-    deployer
-  );
-  expect(res.result).toHaveClarityType(ClarityType.ResponseOk);
-
-  return publishTime;
+  return set_price_at(feed, price, expo, getPublishTimeMicros(), deployer);
 };

--- a/tests/staking.test.ts
+++ b/tests/staking.test.ts
@@ -668,7 +668,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -730,7 +729,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -935,7 +933,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1011,7 +1008,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1244,7 +1240,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1320,7 +1315,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1513,7 +1507,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1543,7 +1536,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1654,7 +1646,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1684,7 +1675,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1855,7 +1845,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-eth"),
         Cl.principal(borrower1),
         Cl.uint(1000),
@@ -1939,7 +1928,6 @@ describe("staking tests", () => {
       "liquidator-v1",
       "liquidate-collateral",
       [
-        Cl.none(),
         Cl.contractPrincipal(deployer, "mock-btc"),
         Cl.principal(borrower1),
         Cl.uint(1000),

--- a/tests/staking.test.ts
+++ b/tests/staking.test.ts
@@ -538,7 +538,7 @@ describe("staking tests", () => {
     // accrued interest math to settle a slightly different staked-LP total.
     expectUserLpBalance(
       Cl.contractPrincipal(deployer, "staking-v1"),
-      500054682070n
+      500054709521n
     );
 
     // initiate unstake of depositor 1 at index 0
@@ -548,7 +548,7 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     const withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500054682070));
+    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500054709521));
     expect(withdrawal.data["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
@@ -560,7 +560,7 @@ describe("staking tests", () => {
 
     // depositor1 got full lp tokens of staking contract.
     // Post H-01: 2-block init shift slightly changes accrued-interest math.
-    expectUserLpBalance(Cl.principal(depositor1), 1000054682070n);
+    expectUserLpBalance(Cl.principal(depositor1), 1000054709521n);
     expectUserStakedLpBalance(Cl.principal(depositor1), 0n);
     expectUserLpBalance(Cl.contractPrincipal(deployer, "staking-v1"), 0n);
   });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -112,7 +112,7 @@ export const borrow = (amount: number, user: any) => {
   const response = simnet.callPublicFn(
     "borrower-v1",
     "borrow",
-    [Cl.none(), Cl.uint(amount), Cl.none()],
+    [Cl.uint(amount), Cl.none()],
     user
   );
   expect(response.result).toBeOk(Cl.bool(true));
@@ -153,7 +153,6 @@ export const remove_collateral = (
     "borrower-v1",
     "remove-collateral",
     [
-      Cl.none(),
       Cl.contractPrincipal(deployer, collateral),
       Cl.uint(amount),
       Cl.none(),
@@ -339,7 +338,7 @@ export const deposit_and_borrow = (
   const borrow = simnet.callPublicFn(
     "borrower-v1",
     "borrow",
-    [Cl.none(), Cl.uint(borrow_amount), Cl.none()],
+    [Cl.uint(borrow_amount), Cl.none()],
     borrower
   );
   expect(borrow.result).toBeOk(Cl.bool(true));


### PR DESCRIPTION
Pyth is retiring the Core pull oracle (Pythnet sunsets and the Core feeds stop July 31), so this moves us to Pyth Lazer, the push-based replacement Hiro has deployed to testnet.

It's contained to `pyth-adapter-v1`, which now reads from `pyth-lazer-storage` (numeric feed ids, microsecond timestamps converted to seconds, optional confidence) instead of the Wormhole VAA path. The relayer keeps storage fresh, so there's no inline price submission anymore: I dropped `update-pyth` and the `pyth-price-feed-data` params on borrow/remove-collateral/batch-liquidate/liquidate-collateral. Wormhole and the Core `stacks-pyth-bridge` submodule are removed, and the governance feed-config path stays with its feed id switched to `uint`.

For tests I didn't vendor Hiro's full contract stack, just a small `pyth-lazer-storage` double that exposes the production `get-price` interface plus a setter, so the adapter's staleness / exponent-bound / confidence / zero-price scenarios run against the real record shape.

The feed ids are placeholders until Hiro publishes the mainnet Lazer catalog; the actual mainnet addresses and the per-market cutover come once their mainnet is live, so this is a draft until then.
