### PR TITLE
bump test stack to clarinet-sdk 3.x and stacks.js 7 for epoch 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
         uses: docker://hirosystems/clarinet:latest
         with:
           args: check
-      - name: "Restore deployment plan"
-        # clarinet check rewrites the simnet plan into a format the sdk
-        # cannot parse; restore the committed one before vitest.
-        run: git checkout -- deployments/default.simnet-plan.yaml
       - name: "Setup Node.js"
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,14 @@ jobs:
         uses: docker://hirosystems/clarinet:latest
         with:
           args: check
+      - name: "Restore deployment plan"
+        # clarinet check rewrites the simnet plan into a format the sdk
+        # cannot parse; restore the committed one before vitest.
+        run: git checkout -- deployments/default.simnet-plan.yaml
       - name: "Setup Node.js"
         uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "20.x"
       - name: "Prep CI"
         run: npm ci
       - name: "Execute unit tests"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,84 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@fast-check/vitest": "^0.1.3",
-        "@hirosystems/clarinet-sdk": "^2.9.0",
+        "@fast-check/vitest": "^0.3.0",
         "@noble/hashes": "^1.5.0",
         "@noble/secp256k1": "^2.1.0",
-        "@stacks/transactions": "^6.16.1",
+        "@stacks/clarinet-sdk": "^3.21.1",
+        "@stacks/transactions": "7.4.0",
         "chokidar-cli": "^3.0.0",
         "fast-check": "^3.22.0",
         "typescript": "^5.6.2",
         "vite": "^5.4.8",
-        "vitest": "^1.6.1",
-        "vitest-environment-clarinet": "^2.1.0"
+        "vitest": "^3.2.7",
+        "vitest-environment-clarinet": "^3.0.2"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.9.5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -40,10 +104,298 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@fast-check/vitest": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.1.3.tgz",
-      "integrity": "sha512-mdLtUVdR/dmmSifzFsY/69Bz+EQDxzdUIDrTfLVfRyebgzVGoA7iuHPwQIN438naHwcm7XyDz05MCA3Tl8v56w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.3.0.tgz",
+      "integrity": "sha512-mXxAu7DJtzwSUeOMecZibq/403b8uX1/dWWXXCBgb+j9ERWuN9Hvr6usId+9ivdQ+tJl8H6o+CMv71BmjaENRQ==",
       "funding": [
         {
           "type": "individual",
@@ -54,53 +406,18 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "dependencies": {
-        "fast-check": "^3.0.0"
-      },
-      "peerDependencies": {
-        "vitest": ">=0.28.1 <1.0.0 || ^1 || ^2"
-      }
-    },
-    "node_modules/@hirosystems/clarinet-sdk": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk/-/clarinet-sdk-2.9.0.tgz",
-      "integrity": "sha512-9Ad4fbcdEa285ap6grpj9OXmDv5e0W5uYYIlM0zY5xRwqy3rTSjoTSnhjkN3Yy3t4BixOHuZhbwpz9lMIGT1LA==",
-      "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "^2.9.0",
-        "@stacks/transactions": "^6.13.0",
-        "kolorist": "^1.8.0",
-        "prompts": "^2.4.2",
-        "vitest": "^1.0.4",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "clarinet-sdk": "dist/cjs/node/src/bin/index.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm/-/clarinet-sdk-wasm-2.9.0.tgz",
-      "integrity": "sha512-5jLGWbHU4TlhMR4UwTjkASpd8WbKve1t1WwJxSAs4KITlNd84ZfPbs5jx+O092CCinbnbyyaiC9q4ur8H+MtdQ=="
-    },
-    "node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "fast-check": "^3.0.0 || ^4.0.0"
       },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      "peerDependencies": {
+        "vitest": "^1 || ^2 || ^3 || ^4"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@noble/hashes": {
@@ -314,39 +631,54 @@
         "win32"
       ]
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "license": "MIT"
-    },
-    "node_modules/@stacks/common": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.16.0.tgz",
-      "integrity": "sha512-PnzvhrdGRMVZvxTulitlYafSK4l02gPCBBoI9QEoTqgSnv62oaOXhYAUUkTMFKxdHW1seVEwZsrahuXiZPIAwg==",
+    "node_modules/@stacks/clarinet-sdk": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.21.1.tgz",
+      "integrity": "sha512-hsmrfXYBqwSMGIt8AuTasCaEDB9ZCJdwaUthmtsjRjW6pAq1LyIWAct/Mc8okk4DAeECjBZ+yn5W6x2qrj6sxg==",
+      "license": "GPL-3.0",
       "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "@types/node": "^18.0.4"
+        "@stacks/clarinet-sdk-wasm": "3.21.1",
+        "@stacks/transactions": "7.4.0",
+        "kolorist": "1.8.0",
+        "prompts": "2.4.2",
+        "yargs": "18.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
+    "node_modules/@stacks/clarinet-sdk-wasm": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.21.1.tgz",
+      "integrity": "sha512-sBhTgYe5V6G5MOFBJaLq/VvirF/VTWD6W0950AWoEkTwLEUxL82HIXcUKmtKPHvSvxi//h0Qhc/FT8DAYNxGPg==",
+      "license": "GPL-3.0"
+    },
+    "node_modules/@stacks/common": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.5.0.tgz",
+      "integrity": "sha512-UkKM3J7VufGEEuHLYRAFZQFbiQeACMpMMzGbBL6qo/6YLXvPPXA8MBffeCsXE65/a0bJSbh+0Q7rfdio9IvZ1w==",
+      "license": "MIT"
+    },
     "node_modules/@stacks/network": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-6.16.0.tgz",
-      "integrity": "sha512-uqz9Nb6uf+SeyCKENJN+idt51HAfEeggQKrOMfGjpAeFgZV2CR66soB/ci9+OVQR/SURvasncAz2ScI1blfS8A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.5.0.tgz",
+      "integrity": "sha512-FKfw864+ipj0RBa0kXBCKp+6Bm/8IS1pk+jg5NJhi//NzG8fZsC4MsER1F8qvzVoFrLfZjqxo+3sJDYfvHbVOQ==",
+      "license": "MIT",
       "dependencies": {
-        "@stacks/common": "^6.16.0",
+        "@stacks/common": "^7.5.0",
         "cross-fetch": "^3.1.5"
       }
     },
     "node_modules/@stacks/transactions": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-6.16.1.tgz",
-      "integrity": "sha512-yCtUM+8IN0QJbnnlFhY1wBW7Q30Cxje3Zmy8DgqdBoM/EPPWadez/8wNWFANVAMyUZeQ9V/FY+8MAw4E+pCReA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
+      "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",
         "@noble/secp256k1": "1.7.1",
-        "@stacks/common": "^6.16.0",
-        "@stacks/network": "^6.16.0",
+        "@stacks/common": "^7.3.1",
+        "@stacks/network": "^7.3.1",
         "c32check": "^2.0.0",
         "lodash.clonedeep": "^4.5.0"
       }
@@ -373,133 +705,154 @@
         }
       ]
     },
-    "node_modules/@types/bn.js": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
-      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
-    "node_modules/@types/node": {
-      "version": "18.19.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.54.tgz",
-      "integrity": "sha512-+BRgt0G5gYjTvdLac9sIeE0iZcJxi4Jc4PV5EUzqi+88jmQLr+fRZdv2tCTV7IHKSGxM6SaLoOXQWWUiLUItMw==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/@vitest/expect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
-        "chai": "^4.3.10"
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "1.6.1",
-        "p-limit": "^5.0.0",
-        "pathe": "^1.1.1"
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "license": "MIT",
       "dependencies": {
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "pretty-format": "^29.7.0"
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^2.2.0"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "license": "MIT",
       "dependencies": {
-        "diff-sequences": "^29.6.3",
-        "estree-walker": "^3.0.3",
-        "loupe": "^2.3.7",
-        "pretty-format": "^29.7.0"
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -518,12 +871,12 @@
       }
     },
     "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/base-x": {
@@ -583,33 +936,28 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "license": "MIT",
       "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -763,16 +1111,17 @@
       }
     },
     "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/color-convert": {
@@ -788,37 +1137,19 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
-    "node_modules/confbox": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
-      "integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA=="
-    },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
       "license": "MIT",
       "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -841,30 +1172,25 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -907,6 +1233,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -920,26 +1247,13 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-check": {
@@ -1006,21 +1320,13 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1035,14 +1341,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "engines": {
-        "node": ">=16.17.0"
       }
     },
     "node_modules/is-binary-path": {
@@ -1064,14 +1362,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1091,26 +1381,11 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
     "node_modules/js-tokens": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
-      "integrity": "sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -1124,21 +1399,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
-    },
-    "node_modules/local-pkg": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
-      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
-      "dependencies": {
-        "mlly": "^1.4.2",
-        "pkg-types": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
     },
     "node_modules/locate-path": {
       "version": "3.0.0",
@@ -1168,48 +1428,18 @@
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
-    "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mlly": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
-      "integrity": "sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==",
-      "dependencies": {
-        "acorn": "^8.11.3",
-        "pathe": "^1.1.2",
-        "pkg-types": "^1.1.1",
-        "ufo": "^1.5.3"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1240,6 +1470,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1261,60 +1492,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -1358,26 +1535,19 @@
         "node": ">=4"
       }
     },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
     },
     "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1394,16 +1564,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
-      "integrity": "sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==",
-      "dependencies": {
-        "confbox": "^0.1.7",
-        "mlly": "^1.7.1",
-        "pathe": "^1.1.2"
       }
     },
     "node_modules/postcss": {
@@ -1433,20 +1593,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -1473,12 +1619,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
-    },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -1555,40 +1695,10 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -1609,51 +1719,50 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.0.tgz",
-      "integrity": "sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==",
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
       "dependencies": {
-        "js-tokens": "^9.0.0"
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1664,18 +1773,79 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="
     },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
-      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -1695,16 +1865,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.6.2",
@@ -1717,16 +1879,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/ufo": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
-      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/vite": {
       "version": "5.4.18",
@@ -1788,73 +1940,80 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
-      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.4",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "vite": "^5.0.0"
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "1.6.1",
-        "@vitest/runner": "1.6.1",
-        "@vitest/snapshot": "1.6.1",
-        "@vitest/spy": "1.6.1",
-        "@vitest/utils": "1.6.1",
-        "acorn-walk": "^8.3.2",
-        "chai": "^4.3.10",
-        "debug": "^4.3.4",
-        "execa": "^8.0.1",
-        "local-pkg": "^0.5.0",
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "std-env": "^3.5.0",
-        "strip-literal": "^2.0.0",
-        "tinybench": "^2.5.1",
-        "tinypool": "^0.8.3",
-        "vite": "^5.0.0",
-        "vite-node": "1.6.1",
-        "why-is-node-running": "^2.2.2"
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.1",
-        "@vitest/ui": "1.6.1",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
@@ -1875,40 +2034,41 @@
       }
     },
     "node_modules/vitest-environment-clarinet": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vitest-environment-clarinet/-/vitest-environment-clarinet-2.1.0.tgz",
-      "integrity": "sha512-1SA9XZh47qmbV724sGo2FyjVU+Ar3m5TOU4bLGSlWDb/x388IKUPrHbHWqIQNwY+gwEm9VBfXEAd1LOSUdemBw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vitest-environment-clarinet/-/vitest-environment-clarinet-3.0.2.tgz",
+      "integrity": "sha512-zuK2KTOw2iISG9nsxO1kH3FPHBQT3fe96NJkYUb5CZqsRKcMetTPxTYiF+Sw+Y4WjSPc9bWmv1hY4o8A49ci3w==",
+      "license": "GPL-3.0",
       "peerDependencies": {
-        "@hirosystems/clarinet-sdk": ">=2.6.0",
-        "vitest": "^1.5.2"
+        "@stacks/clarinet-sdk": ">=3.8.1",
+        "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which-module": {
@@ -1932,94 +2092,55 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^7.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^22.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,17 +12,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@fast-check/vitest": "^0.1.3",
-    "@hirosystems/clarinet-sdk": "^2.9.0",
+    "@fast-check/vitest": "^0.3.0",
     "@noble/hashes": "^1.5.0",
     "@noble/secp256k1": "^2.1.0",
-    "@stacks/transactions": "^6.16.1",
+    "@stacks/clarinet-sdk": "^3.21.1",
+    "@stacks/transactions": "7.4.0",
     "chokidar-cli": "^3.0.0",
     "fast-check": "^3.22.0",
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
-    "vitest": "^1.6.1",
-    "vitest-environment-clarinet": "^2.1.0"
+    "vitest": "^3.2.7",
+    "vitest-environment-clarinet": "^3.0.2"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.9.5"

--- a/tests/borrower.test.ts
+++ b/tests/borrower.test.ts
@@ -157,7 +157,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data.collaterals.list[0]).toStrictEqual(
+    expect(position.result.value.value.collaterals.value[0]).toStrictEqual(
       Cl.contractPrincipal(deployer, "mock-btc")
     );
 
@@ -169,7 +169,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data.collaterals.list.length).toBe(0);
+    expect(position.result.value.value.collaterals.value.length).toBe(0);
   });
 
   it("should not allow adding collateral with 0 maxltv", async () => {
@@ -219,13 +219,13 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data.collaterals.list[0]).toStrictEqual(
+    expect(position.result.value.value.collaterals.value[0]).toStrictEqual(
       Cl.contractPrincipal(deployer, "mock-btc")
     );
-    expect(position.result.value.data.collaterals.list[1]).toStrictEqual(
+    expect(position.result.value.value.collaterals.value[1]).toStrictEqual(
       Cl.contractPrincipal(deployer, "mock-eth")
     );
-    expect(position.result.value.data.collaterals.list.length).toBe(2);
+    expect(position.result.value.value.collaterals.value.length).toBe(2);
 
     const collateralVal = simnet.callReadOnlyFn(
       "borrower-v1",
@@ -243,13 +243,13 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data.collaterals.list[0]).toStrictEqual(
+    expect(position.result.value.value.collaterals.value[0]).toStrictEqual(
       Cl.contractPrincipal(deployer, "mock-btc")
     );
-    expect(position.result.value.data.collaterals.list[1]).toStrictEqual(
+    expect(position.result.value.value.collaterals.value[1]).toStrictEqual(
       Cl.contractPrincipal(deployer, "mock-eth")
     );
-    expect(position.result.value.data.collaterals.list.length).toBe(2);
+    expect(position.result.value.value.collaterals.value.length).toBe(2);
 
     // mock eth should be removed from the array as it was totally withdrawn
     remove_collateral("mock-eth", 90000000000, deployer, borrower1);
@@ -259,10 +259,10 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data.collaterals.list[0]).toStrictEqual(
+    expect(position.result.value.value.collaterals.value[0]).toStrictEqual(
       Cl.contractPrincipal(deployer, "mock-btc")
     );
-    expect(position.result.value.data.collaterals.list.length).toBe(1);
+    expect(position.result.value.value.collaterals.value.length).toBe(1);
   });
 
   it("should correctly borrow", async () => {
@@ -403,7 +403,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data.collaterals.list[0]).toStrictEqual(
+    expect(position.result.value.value.collaterals.value[0]).toStrictEqual(
       Cl.contractPrincipal(deployer, "mock-btc")
     );
 
@@ -425,7 +425,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data.collaterals.list.length).toBe(0);
+    expect(position.result.value.value.collaterals.value.length).toBe(0);
 
     contractBalance = simnet.callReadOnlyFn(
       "mock-btc",
@@ -554,7 +554,7 @@ describe("borrower tests", () => {
       [],
       deployer
     );
-    expect(open_interest.result.data["lp-open-interest"].value).toBe(
+    expect(open_interest.result.value["lp-open-interest"].value).toBe(
       170000007825n
     );
 
@@ -599,7 +599,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(initialDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(initialDebtShares.result.value.value["debt-shares"].value).toEqual(
       10000000000n
     );
 
@@ -637,7 +637,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(
       5000000595n
     );
 
@@ -650,7 +650,7 @@ describe("borrower tests", () => {
       borrower1
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
-    let repaidAmount = repay.events[3].data.value.data.assets.value;
+    let repaidAmount = repay.events[3].data.value.value.assets.value;
     let remainingAmount = BigInt(6000000000) - repaidAmount;
 
     // user should have zero debt shares
@@ -660,7 +660,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     // User should have close to 9.7 assets post full repay including interest
     userBalancePostBorrow = simnet.callReadOnlyFn(
@@ -701,7 +701,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(initialDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(initialDebtShares.result.value.value["debt-shares"].value).toEqual(
       10000000000n
     );
 
@@ -724,7 +724,7 @@ describe("borrower tests", () => {
     );
     expect(borrow.result).toBeOk(Cl.bool(true));
 
-    let repaidAmount = repay.events[3].data.value.data.assets.value;
+    let repaidAmount = repay.events[3].data.value.value.assets.value;
     let remainingAmount = BigInt(11000000000) - repaidAmount;
 
     // user should have zero debt shares
@@ -734,7 +734,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     // User should have close to 9.7 assets post full repay including interest
     userBalancePostBorrow = simnet.callReadOnlyFn(
@@ -777,7 +777,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(initialDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(initialDebtShares.result.value.value["debt-shares"].value).toEqual(
       10000000000n
     );
 
@@ -808,7 +808,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
   });
 
   it("Stock price manipulation through free-liquidity should not happen", async () => {
@@ -1019,7 +1019,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     remove_collateral("mock-btc", 54994875, deployer, borrower1);
   });
@@ -1088,7 +1088,7 @@ describe("borrower tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     remove_collateral("mock-btc", 549948753641, deployer, borrower1);
   });
@@ -1149,7 +1149,7 @@ describe("borrower tests", () => {
           [],
           deployer
         );
-        let currentTotalAssets = lpParams.result?.data?.["total-assets"].value;
+        let currentTotalAssets = lpParams.result?.value?.["total-assets"].value;
         let depositAmount = 2n * currentTotalAssets - 1n; // 2 * totalAssets - 1
         depositResult = simnet.callPublicFn(
           "liquidity-provider-v1",
@@ -1174,7 +1174,7 @@ describe("borrower tests", () => {
         [],
         deployer
       );
-      let finalTotalAssets = lpParams.result?.data?.["total-assets"]?.value;
+      let finalTotalAssets = lpParams.result?.value?.["total-assets"]?.value;
       let victimDepositAmountFinal = (19n * finalTotalAssets) / 10n;
       let victimDeposit = simnet.callPublicFn(
         "liquidity-provider-v1",
@@ -1198,9 +1198,9 @@ describe("borrower tests", () => {
         deployer
       );
       let finalAssetsAfterVictim =
-        finalLpParams.result?.data?.["total-assets"]?.value;
+        finalLpParams.result?.value?.["total-assets"]?.value;
       let finalSharesAfterVictim =
-        finalLpParams.result?.data?.["total-shares"]?.value;
+        finalLpParams.result?.value?.["total-shares"]?.value;
 
       let shareValueFinal =
         Number(finalAssetsAfterVictim) / Number(finalSharesAfterVictim);
@@ -1423,7 +1423,7 @@ describe("M-01 interest-dust no-stakers regression", () => {
     const socializedEvent = res.events.find(
       (e: any) =>
         e.event === "print_event" &&
-        e.data?.value?.data?.action?.data === "socialized-bad-debt"
+        e.data?.value?.value?.action?.value === "socialized-bad-debt"
     );
     expect(socializedEvent).toBeDefined();
   });

--- a/tests/borrower_flow.test.ts
+++ b/tests/borrower_flow.test.ts
@@ -160,7 +160,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data["debt-shares"].value).toBe(0n);
+    expect(position.result.value.value["debt-shares"].value).toBe(0n);
   });
 
   it("Borrower borrows and partial liquidation", async () => {
@@ -191,7 +191,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(115356885n)
     );
 
@@ -207,7 +207,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(98053352n)
     );
 
@@ -233,7 +233,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
 
@@ -286,8 +286,8 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(position.result.value.data["debt-shares"].value).toBe(0n);
-    expect(position.result.value.data["collaterals"].list.length).toBe(0);
+    expect(position.result.value.value["debt-shares"].value).toBe(0n);
+    expect(position.result.value.value["collaterals"].value.length).toBe(0);
   });
 
   it("Borrower borrows and full liquidation", async () => {
@@ -317,7 +317,7 @@ describe("Borrower User flow tests", () => {
       [],
       deployer
     );
-    let totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    let totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3001n);
 
@@ -327,7 +327,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(115356885n)
     );
 
@@ -361,7 +361,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(
       1386n
     );
 
@@ -375,7 +375,7 @@ describe("Borrower User flow tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3001n);
 
@@ -394,7 +394,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(43258832n)
     );
 
@@ -431,7 +431,7 @@ describe("Borrower User flow tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3002n);
 
@@ -457,7 +457,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(796n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(796n);
 
     simnet.mineEmptyBlocks(6);
     // refresh prices after mining blocks
@@ -478,7 +478,7 @@ describe("Borrower User flow tests", () => {
     );
     expect(liquidate.result).toBeOk(Cl.bool(true));
     let socializedDebt =
-      liquidate.events[liquidate.events.length - 2].data.value.data["amount"]
+      liquidate.events[liquidate.events.length - 2].data.value.value["amount"]
         .value;
 
     depositorBalance = simnet.callReadOnlyFn(
@@ -503,7 +503,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
 
@@ -545,7 +545,7 @@ describe("Borrower User flow tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     totalAssetsRes = simnet.callReadOnlyFn(
       "state-v1",
@@ -553,7 +553,7 @@ describe("Borrower User flow tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // this is after socializing the remaining debt from the user.
     // total assets with interest is 2002 + 1000 H-01 burn dust = 3002.
     expect(totalAssets).toEqual(3002n - socializedDebt);

--- a/tests/governance.test.ts
+++ b/tests/governance.test.ts
@@ -30,24 +30,24 @@ const guardian_account = accounts.get("wallet_2")!;
 const deployer = accounts.get("deployer")!;
 
 function execute_proposal(response: any) {
-  const proposal_id = response.result.value.buffer;
+  const proposal_id = response.result.value.value;
   simnet.mineEmptyBlocks(21600);
   const res = simnet.callPublicFn(
     "governance-v1",
     "execute",
-    [Cl.buffer(proposal_id)],
+    [Cl.bufferFromHex(proposal_id)],
     governance_account
   );
   expect(res.result).toBeOk(Cl.bool(true));
 }
 
 function execute_proposal_failed(response: any, error: any) {
-  const proposal_id = response.result.value.buffer;
+  const proposal_id = response.result.value.value;
   simnet.mineEmptyBlocks(21600);
   const res = simnet.callPublicFn(
     "governance-v1",
     "execute",
-    [Cl.buffer(proposal_id)],
+    [Cl.bufferFromHex(proposal_id)],
     governance_account
   );
   expect(res.result).toBeErr(Cl.uint(error));
@@ -418,7 +418,7 @@ describe("governance tests", () => {
       [Cl.contractPrincipal(deployer, "mock-btc")],
       governance_account
     );
-    expect(response.result.value.data["max-ltv"]).toEqual(Cl.uint(90000000));
+    expect(response.result.value.value["max-ltv"]).toEqual(Cl.uint(90000000));
   });
 
   it("update collateral settings should fail with incorrect values", async () => {
@@ -787,7 +787,7 @@ describe("governance tests", () => {
       [],
       deployer
     );
-    expect(response.result.data["base-ir"]).toEqual(Cl.uint(300000000000));
+    expect(response.result.value["base-ir"]).toEqual(Cl.uint(300000000000));
 
     response = simnet.callPublicFn(
       "governance-v1",
@@ -810,7 +810,7 @@ describe("governance tests", () => {
       [],
       deployer
     );
-    expect(response.result.data["base-ir"]).toEqual(Cl.uint(500000000000));
+    expect(response.result.value["base-ir"]).toEqual(Cl.uint(500000000000));
   });
 
   it("staking reward rate params can be upgraded", async () => {
@@ -822,7 +822,7 @@ describe("governance tests", () => {
       [],
       deployer
     );
-    expect(response.result.data["base-reward"]).toEqual(Cl.uint(30000000n));
+    expect(response.result.value["base-reward"]).toEqual(Cl.uint(30000000n));
 
     response = simnet.callPublicFn(
       "governance-v1",
@@ -845,7 +845,7 @@ describe("governance tests", () => {
       [],
       deployer
     );
-    expect(response.result.data["base-reward"]).toEqual(Cl.uint(15000000));
+    expect(response.result.value["base-reward"]).toEqual(Cl.uint(15000000));
   });
 
   it("staking reward window can be upgraded", async () => {
@@ -932,13 +932,13 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    const proposal_id = response.result.value.buffer;
+    const proposal_id = response.result.value.value;
 
     // Immediate execute attempt must fail with ERR-PROPOSAL-TIME-LOCKED.
     let exec = simnet.callPublicFn(
       "governance-v1",
       "execute",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(exec.result).toBeErr(Cl.uint(40017)); // ERR-PROPOSAL-TIME-LOCKED
@@ -951,7 +951,7 @@ describe("governance tests", () => {
     exec = simnet.callPublicFn(
       "governance-v1",
       "execute",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(exec.result).toBeOk(Cl.bool(true));
@@ -988,12 +988,12 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    const proposal_id = response.result.value.buffer;
+    const proposal_id = response.result.value.value;
 
     let exec = simnet.callPublicFn(
       "governance-v1",
       "execute",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(exec.result).toBeErr(Cl.uint(40017)); // ERR-PROPOSAL-TIME-LOCKED
@@ -1002,7 +1002,7 @@ describe("governance tests", () => {
     exec = simnet.callPublicFn(
       "governance-v1",
       "execute",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(exec.result).toBeOk(Cl.bool(true));
@@ -1038,7 +1038,7 @@ describe("governance tests", () => {
       governance_account
     );
     expect(respA.result.type).toBe(ClarityType.ResponseOk);
-    const idA = respA.result.value.buffer;
+    const idA = respA.result.value.value;
 
     // Proposal B: same feed + max-confidence-ratio + expires-in, but a
     // different token. Pre-fix this collided on the same proposal-id and
@@ -1056,11 +1056,9 @@ describe("governance tests", () => {
       governance_account
     );
     expect(respB.result.type).toBe(ClarityType.ResponseOk);
-    const idB = respB.result.value.buffer;
+    const idB = respB.result.value.value;
 
-    expect(Buffer.from(idA).toString("hex")).not.toEqual(
-      Buffer.from(idB).toString("hex")
-    );
+    expect(idA).not.toEqual(idB);
   });
 
   it("governance multisigs can be upgraded", async () => {
@@ -1113,12 +1111,12 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "approve",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       new_governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1214,7 +1212,7 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id_1 = response.result.value.buffer;
+    let proposal_id_1 = response.result.value.value;
 
     // create proposal 2
     response = simnet.callPublicFn(
@@ -1224,13 +1222,13 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id_2 = response.result.value.buffer;
+    let proposal_id_2 = response.result.value.value;
 
     // approve and execute proposal 2
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "approve",
-      [Cl.buffer(proposal_id_2)],
+      [Cl.bufferFromHex(proposal_id_2)],
       new_governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1239,7 +1237,7 @@ describe("governance tests", () => {
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "approve",
-      [Cl.buffer(proposal_id_1)],
+      [Cl.bufferFromHex(proposal_id_1)],
       new_governance_account
     );
     expect(response.result).toBeErr(Cl.uint(50008));
@@ -1288,7 +1286,7 @@ describe("governance tests", () => {
       new_governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id_1 = response.result.value.buffer;
+    let proposal_id_1 = response.result.value.value;
 
     // create proposal 2
     response = simnet.callPublicFn(
@@ -1298,13 +1296,13 @@ describe("governance tests", () => {
       new_governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id_2 = response.result.value.buffer;
+    let proposal_id_2 = response.result.value.value;
 
     // approve and execute proposal 2
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "approve",
-      [Cl.buffer(proposal_id_2)],
+      [Cl.bufferFromHex(proposal_id_2)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1313,7 +1311,7 @@ describe("governance tests", () => {
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "approve",
-      [Cl.buffer(proposal_id_1)],
+      [Cl.bufferFromHex(proposal_id_1)],
       governance_account
     );
     expect(response.result).toBeErr(Cl.uint(50009));
@@ -1363,12 +1361,12 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "approve",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       new_governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1389,13 +1387,13 @@ describe("governance tests", () => {
       new_governance_account_1
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    proposal_id = response.result.value.buffer;
+    proposal_id = response.result.value.value;
 
     // rest of multisigs denies and closes the proposal
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       new_governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1403,7 +1401,7 @@ describe("governance tests", () => {
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1420,10 +1418,10 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "meta-governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["completed"]).toEqual(Cl.bool(true));
+    expect(response.result.value.value["completed"]).toEqual(Cl.bool(true));
   });
 
   it("protocol reserve percentage can be upgraded", async () => {
@@ -1597,12 +1595,12 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "approve",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       new_governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1625,12 +1623,12 @@ describe("governance tests", () => {
       new_governance_account_1
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    proposal_id = response.result.value.buffer;
+    proposal_id = response.result.value.value;
 
     response = simnet.callPublicFn(
       "governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       new_governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1638,7 +1636,7 @@ describe("governance tests", () => {
     response = simnet.callPublicFn(
       "governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1647,10 +1645,10 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["closed"]).toEqual(Cl.bool(true));
+    expect(response.result.value.value["closed"]).toEqual(Cl.bool(true));
 
     response = simnet.callReadOnlyFn("state-v1", "get-asset-cap", [], deployer);
     expect(response.result).toEqual(Cl.uint(10000000000000n));
@@ -1695,12 +1693,12 @@ describe("governance tests", () => {
       new_governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     response = simnet.callPublicFn(
       "governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1709,16 +1707,16 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["closed"]).toEqual(Cl.bool(false));
+    expect(response.result.value.value["closed"]).toEqual(Cl.bool(false));
 
     // close the proposal since of there 50% threshold met for both approval and denial and everyone voted
     response = simnet.callPublicFn(
       "governance-v1",
       "close",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1727,10 +1725,10 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["closed"]).toEqual(Cl.bool(true));
+    expect(response.result.value.value["closed"]).toEqual(Cl.bool(true));
 
     response = simnet.callReadOnlyFn("state-v1", "get-asset-cap", [], deployer);
     expect(response.result).toEqual(Cl.uint(10000000000000n));
@@ -1775,14 +1773,14 @@ describe("governance tests", () => {
       new_governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     simnet.mineEmptyBlocks(15);
 
     response = simnet.callPublicFn(
       "governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeErr(Cl.uint(40013)); // proposal expired
@@ -1791,16 +1789,16 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["closed"]).toEqual(Cl.bool(false));
+    expect(response.result.value.value["closed"]).toEqual(Cl.bool(false));
 
     // close the proposal since its expired even if voting is incomplete
     response = simnet.callPublicFn(
       "governance-v1",
       "close",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1809,10 +1807,10 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["closed"]).toEqual(Cl.bool(true));
+    expect(response.result.value.value["closed"]).toEqual(Cl.bool(true));
 
     response = simnet.callReadOnlyFn("state-v1", "get-asset-cap", [], deployer);
     expect(response.result).toEqual(Cl.uint(10000000000000n));
@@ -1854,12 +1852,12 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       new_governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1868,16 +1866,16 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "meta-governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["completed"]).toEqual(Cl.bool(false));
+    expect(response.result.value.value["completed"]).toEqual(Cl.bool(false));
 
     // close the proposal since of there 50% threshold met for both approval and denial and everyone voted
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "close",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1894,10 +1892,10 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "meta-governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["completed"]).toEqual(Cl.bool(true));
+    expect(response.result.value.value["completed"]).toEqual(Cl.bool(true));
   });
 
   it("multisig proposal can be expired and closed", async () => {
@@ -1936,7 +1934,7 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     // mine blocks so that proposal is expired
     simnet.mineEmptyBlocks(15);
@@ -1944,7 +1942,7 @@ describe("governance tests", () => {
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "deny",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       new_governance_account
     );
     expect(response.result).toBeErr(Cl.uint(50015)); // proposal expired
@@ -1953,16 +1951,16 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "meta-governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["completed"]).toEqual(Cl.bool(false));
+    expect(response.result.value.value["completed"]).toEqual(Cl.bool(false));
 
     // close proposal since its expired even if the voting is incomplete
     response = simnet.callPublicFn(
       "meta-governance-v1",
       "close",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -1979,10 +1977,10 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "meta-governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["completed"]).toEqual(Cl.bool(true));
+    expect(response.result.value.value["completed"]).toEqual(Cl.bool(true));
   });
 
   it("market timelocked proposal can be expired and closed", async () => {
@@ -2003,25 +2001,25 @@ describe("governance tests", () => {
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    let proposal_id = response.result.value.buffer;
+    let proposal_id = response.result.value.value;
 
     // proposal should be not closed
     response = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["closed"]).toEqual(Cl.bool(false));
-    expect(response.result.value.data["executed"]).toEqual(Cl.bool(false));
+    expect(response.result.value.value["closed"]).toEqual(Cl.bool(false));
+    expect(response.result.value.value["executed"]).toEqual(Cl.bool(false));
 
     let block_number = simnet.blockHeight;
     let execute_at = block_number + 21600;
     let expires_at = execute_at + 151200;
-    expect(response.result.value.data["execute-at"]).toEqual(
+    expect(response.result.value.value["execute-at"]).toEqual(
       Cl.some(Cl.uint(execute_at))
     );
-    expect(response.result.value.data["expires-at"]).toEqual(
+    expect(response.result.value.value["expires-at"]).toEqual(
       Cl.uint(expires_at)
     );
 
@@ -2031,7 +2029,7 @@ describe("governance tests", () => {
     const res = simnet.callPublicFn(
       "governance-v1",
       "execute",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(res.result).toBeErr(Cl.uint(40013)); // ERR-PROPOSAL-EXPIRED
@@ -2040,7 +2038,7 @@ describe("governance tests", () => {
     response = simnet.callPublicFn(
       "governance-v1",
       "close",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -2049,11 +2047,11 @@ describe("governance tests", () => {
     response = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       deployer
     );
-    expect(response.result.value.data["closed"]).toEqual(Cl.bool(true));
-    expect(response.result.value.data["executed"]).toEqual(Cl.bool(false));
+    expect(response.result.value.value["closed"]).toEqual(Cl.bool(true));
+    expect(response.result.value.value["executed"]).toEqual(Cl.bool(false));
 
     response = simnet.callReadOnlyFn(
       "state-v1",
@@ -2127,7 +2125,7 @@ describe("governance tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     // remove collateral should fail
     response = simnet.callPublicFn(
@@ -2322,12 +2320,12 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
       governance_account
     );
     expect(res.result.type).toBe(ClarityType.ResponseOk);
-    const pid = (res.result as any).value.buffer;
+    const pid = (res.result as any).value.value;
     for (const v of voters) {
       const r = simnet.callPublicFn(
         "meta-governance-v1",
         "approve",
-        [Cl.buffer(pid)],
+        [Cl.bufferFromHex(pid)],
         v
       );
       expect(r.result).toBeOk(Cl.bool(true));
@@ -2348,10 +2346,10 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
     const r = simnet.callReadOnlyFn(
       "governance-v1",
       "get-proposal",
-      [Cl.buffer(pid)],
+      [Cl.bufferFromHex(pid)],
       deployer
     );
-    return ((r.result as any).value as any).data;
+    return ((r.result as any).value as any).value;
   };
 
   it("multisig growth during timelock cannot strand an approved proposal at execute-time", async () => {
@@ -2376,7 +2374,7 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    const pid = (response.result as any).value.buffer;
+    const pid = (response.result as any).value.value;
 
     // Snapshot captured at creation must equal current multisig count.
     expect(getProposal(pid)["member-count"]).toEqual(Cl.uint(3));
@@ -2386,7 +2384,7 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
     response = simnet.callPublicFn(
       "governance-v1",
       "approve",
-      [Cl.buffer(pid)],
+      [Cl.bufferFromHex(pid)],
       wallet_3
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -2405,7 +2403,7 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
     response = simnet.callPublicFn(
       "governance-v1",
       "execute",
-      [Cl.buffer(pid)],
+      [Cl.bufferFromHex(pid)],
       governance_account
     );
     expect(response.result).toBeOk(Cl.bool(true));
@@ -2422,7 +2420,7 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
       [],
       deployer
     );
-    expect((irParams.result as any).data["base-ir"]).toEqual(
+    expect((irParams.result as any).value["base-ir"]).toEqual(
       Cl.uint(500000000000)
     );
   });
@@ -2448,7 +2446,7 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
       governance_account
     );
     expect(response.result.type).toBe(ClarityType.ResponseOk);
-    const pid = (response.result as any).value.buffer;
+    const pid = (response.result as any).value.value;
     expect(getProposal(pid)["member-count"]).toEqual(Cl.uint(4));
     expect(getProposal(pid)["execute-at"]).toEqual(Cl.none());
 
@@ -2462,12 +2460,12 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
         governance_account
       );
       expect(r.result.type).toBe(ClarityType.ResponseOk);
-      const rpid = (r.result as any).value.buffer;
+      const rpid = (r.result as any).value.value;
       for (const v of voters) {
         const rr = simnet.callPublicFn(
           "meta-governance-v1",
           "approve",
-          [Cl.buffer(rpid)],
+          [Cl.bufferFromHex(rpid)],
           v
         );
         expect(rr.result).toBeOk(Cl.bool(true));
@@ -2487,7 +2485,7 @@ describe("LEV-L-01: governance proposal snapshots member-count at creation", () 
     response = simnet.callPublicFn(
       "governance-v1",
       "approve",
-      [Cl.buffer(pid)],
+      [Cl.bufferFromHex(pid)],
       wallet_3
     );
     expect(response.result).toBeOk(Cl.bool(true));

--- a/tests/liquidation.test.ts
+++ b/tests/liquidation.test.ts
@@ -18,7 +18,7 @@ import {
   expectUserBTCBalance,
   state_set_governance_contract,
 } from "./utils";
-import { tx } from "@hirosystems/clarinet-sdk";
+import { tx } from "@stacks/clarinet-sdk";
 import {
   init_pyth,
   set_initial_price,
@@ -81,11 +81,11 @@ describe("liquidation tests", () => {
       args,
       borrower1
     );
-    expect(result.result.value.data["repay-amount"]).toStrictEqual(
+    expect(result.result.value.value["repay-amount"]).toStrictEqual(
       Cl.uint(100000000000)
     );
     const collateralToGive =
-      result.result.value.data["collateral-to-give"].value;
+      result.result.value.value["collateral-to-give"].value;
     expect(collateralToGive).toStrictEqual(4888888n);
     expect(collateralToGive).toBeLessThan(depositedCollateral);
   });
@@ -119,11 +119,11 @@ describe("liquidation tests", () => {
       args,
       borrower1
     );
-    expect(result.result.value.data["repay-amount"]).toStrictEqual(
+    expect(result.result.value.value["repay-amount"]).toStrictEqual(
       Cl.uint(53714866n)
     );
     const collateralToGive =
-      result.result.value.data["collateral-to-give"].value;
+      result.result.value.value["collateral-to-give"].value;
     expect(collateralToGive).toStrictEqual(10776689600n);
     expect(collateralToGive).toBeLessThan(depositedCollateral);
   });
@@ -157,11 +157,11 @@ describe("liquidation tests", () => {
       args,
       borrower1
     );
-    expect(result.result.value.data["repay-amount"]).toStrictEqual(
+    expect(result.result.value.value["repay-amount"]).toStrictEqual(
       Cl.uint(90378500n)
     );
     const collateralToGive =
-      result.result.value.data["collateral-to-give"].value;
+      result.result.value.value["collateral-to-give"].value;
     expect(collateralToGive).toStrictEqual(1816556n);
     expect(collateralToGive).toBeLessThan(depositedCollateral);
   });
@@ -195,10 +195,10 @@ describe("liquidation tests", () => {
       args,
       borrower1
     );
-    expect(result.result.value.data["repay-amount"]).toStrictEqual(
+    expect(result.result.value.value["repay-amount"]).toStrictEqual(
       Cl.uint(147272727273)
     );
-    expect(result.result.value.data["collateral-to-give"]).toStrictEqual(
+    expect(result.result.value.value["collateral-to-give"]).toStrictEqual(
       Cl.uint(depositedCollateral)
     );
   });
@@ -232,10 +232,10 @@ describe("liquidation tests", () => {
       args,
       borrower1
     );
-    expect(result.result.value.data["repay-amount"]).toStrictEqual(
+    expect(result.result.value.value["repay-amount"]).toStrictEqual(
       Cl.uint(147272727273)
     );
-    expect(result.result.value.data["collateral-to-give"]).toStrictEqual(
+    expect(result.result.value.value["collateral-to-give"]).toStrictEqual(
       Cl.uint(depositedCollateral)
     );
   });
@@ -269,10 +269,10 @@ describe("liquidation tests", () => {
       args,
       borrower1
     );
-    expect(result.result.value.data["repay-amount"]).toStrictEqual(
+    expect(result.result.value.value["repay-amount"]).toStrictEqual(
       Cl.uint(2241187273n)
     );
-    expect(result.result.value.data["collateral-to-give"]).toStrictEqual(
+    expect(result.result.value.value["collateral-to-give"]).toStrictEqual(
       Cl.uint(depositedCollateral)
     );
   });
@@ -306,10 +306,10 @@ describe("liquidation tests", () => {
       args,
       borrower1
     );
-    expect(result.result.value.data["repay-amount"]).toStrictEqual(
+    expect(result.result.value.value["repay-amount"]).toStrictEqual(
       Cl.uint(69592592592)
     );
-    expect(result.result.value.data["collateral-to-give"]).toStrictEqual(
+    expect(result.result.value.value["collateral-to-give"]).toStrictEqual(
       Cl.uint(3897185)
     );
   });
@@ -347,7 +347,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(105555555n)
     );
 
@@ -366,7 +366,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(55555555n)
     );
 
@@ -392,7 +392,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
   });
@@ -430,7 +430,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(105555555n)
     );
 
@@ -449,7 +449,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(55555555n)
     );
 
@@ -490,7 +490,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(55555555n)
     );
   });
@@ -606,7 +606,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(110256410n)
     );
 
@@ -625,7 +625,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(87179487n)
     );
 
@@ -666,7 +666,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
   });
@@ -700,7 +700,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(3n)
     );
 
@@ -740,7 +740,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(105555555n)
     );
 
@@ -759,7 +759,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(55555555n)
     );
 
@@ -823,7 +823,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(110256410n)
     );
 
@@ -842,7 +842,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(87179487n)
     );
 
@@ -919,7 +919,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(110256394n)
     );
 
@@ -929,7 +929,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower2), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(110256410n)
     );
 
@@ -948,7 +948,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(87179474n)
     );
 
@@ -958,7 +958,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower2), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(87179487n)
     );
 
@@ -1068,7 +1068,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(106250000n)
     );
 
@@ -1080,7 +1080,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(69000229n)
     );
 
@@ -1106,7 +1106,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
   });
@@ -1143,7 +1143,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(114285714n)
     );
 
@@ -1156,7 +1156,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(99551591n)
     );
 
@@ -1183,7 +1183,7 @@ describe("liquidation tests", () => {
       deployer
     );
     // H-01 burn dust shifts position-health rounding by 1 micro-unit.
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000001n)
     );
   });
@@ -1220,7 +1220,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(114285714n)
     );
 
@@ -1233,7 +1233,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(81543219n)
     );
 
@@ -1259,7 +1259,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
   });
@@ -1296,7 +1296,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(114285715n)
     );
 
@@ -1309,7 +1309,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(99733496n)
     );
 
@@ -1335,7 +1335,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
   });
@@ -1372,7 +1372,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(114285715n)
     );
 
@@ -1385,7 +1385,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(81543222n)
     );
 
@@ -1411,7 +1411,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
   });
@@ -1443,7 +1443,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(105555555n)
     );
 
@@ -1462,7 +1462,7 @@ describe("liquidation tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(55555555n)
     );
 

--- a/tests/liquidity_provider.test.ts
+++ b/tests/liquidity_provider.test.ts
@@ -474,7 +474,7 @@ describe("H-01 initialize burn-floor", () => {
         deployer
       );
       expect(
-        lpParams.result.data["total-assets"].value as bigint
+        lpParams.result.value["total-assets"].value as bigint
       ).toBeGreaterThanOrEqual(1000n);
 
       // Burn principal still owns the floor shares.

--- a/tests/lp-incentives.test.ts
+++ b/tests/lp-incentives.test.ts
@@ -41,7 +41,7 @@ function check_closed_epoch() {
     deployer
   );
 
-  expect(res.result.value.data["epoch-completed"]).toStrictEqual(Cl.bool(true));
+  expect(res.result.value.value["epoch-completed"]).toStrictEqual(Cl.bool(true));
 }
 
 const getUserStxBalance = (user: string) => {
@@ -130,7 +130,7 @@ function expectUserRewards(user: string, rewards: number) {
     [Cl.principal(user)],
     deployer
   );
-  expect(user1Rewards.result.value.value.data["earned-rewards"]).toStrictEqual(
+  expect(user1Rewards.result.value.value.value["earned-rewards"]).toStrictEqual(
     Cl.uint(rewards)
   );
 }

--- a/tests/modules/linear-kinked-ir.test.ts
+++ b/tests/modules/linear-kinked-ir.test.ts
@@ -26,7 +26,7 @@ describe("linear kinked interest rate module update-ir-params tests", () => {
       [],
       address1
     );
-    const returnedBaseIR = res.result.data["base-ir"];
+    const returnedBaseIR = res.result.value["base-ir"];
     expect(init.result).toBeOk(Cl.bool(true)); // SUCCESS code
 
     expect(returnedBaseIR).toStrictEqual(baseIR);

--- a/tests/modules/staking-reward.test.ts
+++ b/tests/modules/staking-reward.test.ts
@@ -28,7 +28,7 @@ describe("update-reward-params tests", () => {
       [],
       address1
     );
-    const returnedBaseIR = res.result.data["base-reward"];
+    const returnedBaseIR = res.result.value["base-reward"];
     expect(returnedBaseIR).toStrictEqual(baseReward);
   });
 

--- a/tests/modules/withdrawal-caps.test.ts
+++ b/tests/modules/withdrawal-caps.test.ts
@@ -34,12 +34,12 @@ const ACTION_SET_DECAY_TIME_WINDOW = 34;
 const SCALING_FACTOR = 100000000;
 
 function execute_proposal(response: any) {
-  const proposal_id = response.result.value.buffer;
+  const proposal_id = response.result.value.value;
   simnet.mineEmptyBlocks(21600);
   const res = simnet.callPublicFn(
     "governance-v1",
     "execute",
-    [Cl.buffer(proposal_id)],
+    [Cl.bufferFromHex(proposal_id)],
     deployer
   );
   expect(res.result).toBeOk(Cl.bool(true));

--- a/tests/poc-em01-repay-roundup-underflow.test.ts
+++ b/tests/poc-em01-repay-roundup-underflow.test.ts
@@ -94,9 +94,9 @@ describe("PoC E-M-01: integer-floor repay-allowed > debt underflow", () => {
     );
 
     expect(res.result.type).toBe(ClarityType.ResponseOk);
-    const info = res.result.value.data["repayment-info"];
-    const repayAllowed = info.data["repay-allowed"].value;
-    const debt = info.data["debt"].value;
+    const info = res.result.value.value["repayment-info"];
+    const repayAllowed = info.value["repay-allowed"].value;
+    const debt = info.value["debt"].value;
     console.log(`[A] repay-allowed=${repayAllowed} debt=${debt}`);
 
     // Pre-fix: repay-allowed = 10 > debt = 9.
@@ -150,6 +150,6 @@ describe("PoC E-M-01: integer-floor repay-allowed > debt underflow", () => {
       [Cl.principal(borrower)],
       deployer,
     );
-    expect(post.result.data["user-position"].value.data["debt-shares"].value).toBe(0n);
+    expect(post.result.value["user-position"].value.value["debt-shares"].value).toBe(0n);
   });
 });

--- a/tests/poc-em02-socialize-baddebt-divzero.test.ts
+++ b/tests/poc-em02-socialize-baddebt-divzero.test.ts
@@ -104,6 +104,6 @@ describe("PoC E-M-02: socialize-bad-debt DivisionByZero on full-payoff bad-debt 
       [Cl.principal(borrower)],
       deployer,
     );
-    expect(post.result.data["user-position"].value.data["debt-shares"].value).toBe(0n);
+    expect(post.result.value["user-position"].value.value["debt-shares"].value).toBe(0n);
   });
 });

--- a/tests/poc-l-03-interest-accrual-pause.test.ts
+++ b/tests/poc-l-03-interest-accrual-pause.test.ts
@@ -51,7 +51,7 @@ function getLpOpenInterest(): bigint {
     deployer
   );
   // get-open-interest returns a tuple
-  return (r.result as any).data["lp-open-interest"].value as bigint;
+  return (r.result as any).value["lp-open-interest"].value as bigint;
 }
 
 function setupBorrowerWithDebt() {
@@ -137,12 +137,12 @@ describe("L-03 — interest-accrual pause settles pending interest", () => {
     // initiate-proposal-to-set-market-state does NOT auto-execute on threshold
     // met the way set-market-feature does (existing tests confirm); explicit
     // execute is needed after time-lock window passes.
-    const proposal_id = (r.result as any).value.buffer;
+    const proposal_id = (r.result as any).value.value;
     simnet.mineEmptyBlocks(21600);
     const exec = simnet.callPublicFn(
       "governance-v1",
       "execute",
-      [Cl.buffer(proposal_id)],
+      [Cl.bufferFromHex(proposal_id)],
       governance_account
     );
     expect(exec.result).toBeOk(Cl.bool(true));

--- a/tests/poc-l01-zero-assets-deposit.test.ts
+++ b/tests/poc-l01-zero-assets-deposit.test.ts
@@ -41,7 +41,7 @@ const second   = accounts.get("wallet_2")!;
 
 const getLpParams = () => {
   const r = simnet.callReadOnlyFn("state-v1", "get-lp-params", [], deployer);
-  const data = (r.result as any).data;
+  const data = (r.result as any).value;
   return {
     totalAssets: data["total-assets"].value as bigint,
     totalShares: data["total-shares"].value as bigint,

--- a/tests/poc-slash-underflow.test.ts
+++ b/tests/poc-slash-underflow.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { Cl, ClarityValue } from "@stacks/transactions";
+import { Cl, ClarityType, ClarityValue } from "@stacks/transactions";
 import {
   initialize_ir,
   set_allowed_contracts,
@@ -64,7 +64,7 @@ const initiateUnstake = (user: string, amount: bigint) => {
     user
   );
   // returns (ok withdrawal-index)
-  expect(r.result.type).toBe(7); // ResponseOk
+  expect(r.result.type).toBe(ClarityType.ResponseOk);
 };
 
 const getStakingState = () => {
@@ -152,7 +152,7 @@ describe("PoC: slash-total-staked-lp-tokens underflow", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    const healthBefore = healthRes.result.value.data["position-health"].value;
+    const healthBefore = healthRes.result.value.value["position-health"].value;
     expect(healthBefore).toBeGreaterThanOrEqual(100_000_000n); // ≥ 1.0
 
     // ────────────────────────────────────────────────────────────
@@ -171,7 +171,7 @@ describe("PoC: slash-total-staked-lp-tokens underflow", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    const healthAfter = healthRes.result.value.data["position-health"].value;
+    const healthAfter = healthRes.result.value.value["position-health"].value;
     expect(healthAfter).toBeLessThan(100_000_000n); // < 1.0
 
     // ────────────────────────────────────────────────────────────

--- a/tests/staking.test.ts
+++ b/tests/staking.test.ts
@@ -219,8 +219,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     const withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(1000));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(1000));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -293,8 +293,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     const withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(1000));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(1000));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -343,8 +343,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     let withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(500));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -369,8 +369,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     withdrawal = getUserWithdrawal(depositor1, 1);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(500));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -447,8 +447,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     let withdrawal = getUserWithdrawal(depositor2, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(1000));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(1000));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -468,8 +468,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(2000));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(2000));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -531,7 +531,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     // stake contracts lp balance should have increased.
     // Post H-01: dust + 2-block init shift in mint/initialize call cause the
@@ -548,8 +548,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     const withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500054682070));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(500054682070));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -593,7 +593,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    let totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    let totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3001n);
 
@@ -603,7 +603,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(115356885n)
     );
 
@@ -613,7 +613,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(
       1386n
     );
 
@@ -627,7 +627,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3001n);
 
@@ -646,7 +646,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(43258832n)
     );
 
@@ -684,7 +684,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3002n);
 
@@ -710,7 +710,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(796n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(796n);
 
     mint_token("mock-usdc", 10000, deployer);
     const depositToReserve = simnet.callPublicFn(
@@ -739,7 +739,7 @@ describe("staking tests", () => {
       depositor1
     );
     expect(liquidate.result).toBeOk(Cl.bool(true));
-    let socializedDebt = liquidate.events[5].data.value.data["amount"].value;
+    let socializedDebt = liquidate.events[5].data.value.value["amount"].value;
 
     depositorBalance = simnet.callReadOnlyFn(
       "mock-usdc",
@@ -763,7 +763,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
 
@@ -805,7 +805,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     const reseverBalance = simnet.callReadOnlyFn(
       "state-v1",
@@ -824,7 +824,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // this is after socializing the remaining debt from the user
     // total assets with interest is 2003 + 1000 H-01 burn dust = 3003
     expect(totalAssets).toEqual(3003n);
@@ -860,7 +860,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    let totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    let totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3002n);
 
@@ -870,7 +870,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(115273775n)
     );
 
@@ -880,7 +880,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(
       1385n
     );
 
@@ -894,7 +894,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3002n);
 
@@ -913,7 +913,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(43227665n)
     );
 
@@ -951,7 +951,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3003n);
 
@@ -977,7 +977,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(796n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(796n);
 
     mint_token("mock-usdc", 100, deployer);
     const depositToReserve = simnet.callPublicFn(
@@ -1020,7 +1020,7 @@ describe("staking tests", () => {
       depositor1
     );
     expect(liquidate.result).toBeOk(Cl.bool(true));
-    let socializedDebt = liquidate.events[6].data.value.data["amount"].value;
+    let socializedDebt = liquidate.events[6].data.value.value["amount"].value;
 
     depositorBalance = simnet.callReadOnlyFn(
       "mock-usdc",
@@ -1044,7 +1044,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
 
@@ -1086,7 +1086,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     const reseverBalance = simnet.callReadOnlyFn(
       "state-v1",
@@ -1111,7 +1111,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // this is after socializing the remaining debt from the user.
     // total assets with interest is 2003 + 1000 H-01 burn dust = 3003 baseline.
     expect(totalAssets).toEqual(3004n - socializedDebt - 1n);
@@ -1157,7 +1157,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    let totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    let totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3002n);
 
@@ -1167,7 +1167,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(115273775n)
     );
 
@@ -1177,7 +1177,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(
       1385n
     );
 
@@ -1188,8 +1188,8 @@ describe("staking tests", () => {
 
     // withdrawal should exist
     const withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(500));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -1203,7 +1203,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3003n);
 
@@ -1222,7 +1222,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(43196544n)
     );
 
@@ -1260,7 +1260,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3004n);
 
@@ -1286,7 +1286,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(797n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(797n);
 
     mint_token("mock-usdc", 100, deployer);
     const depositToReserve = simnet.callPublicFn(
@@ -1329,9 +1329,9 @@ describe("staking tests", () => {
       depositor1
     );
     expect(liquidate.result).toBeOk(Cl.bool(true));
-    let socializedDebt = liquidate.events[6].data.value.data["amount"].value;
+    let socializedDebt = liquidate.events[6].data.value.value["amount"].value;
     let burnedStakedLPTokens =
-      liquidate.events[6].data.value.data["burned-staking-lp-tokens"].value;
+      liquidate.events[6].data.value.value["burned-staking-lp-tokens"].value;
     // since staked lp are equally divided between active and withdrawal
     // Withdrawal should yield half of the remaining
     let expectedWithdrawalTokens = (1000n - burnedStakedLPTokens) / 2n;
@@ -1358,7 +1358,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
 
@@ -1400,7 +1400,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     const reseverBalance = simnet.callReadOnlyFn(
       "state-v1",
@@ -1418,7 +1418,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // this is after socializing the remaining debt from the user
     // total assets with interest is 2003 and reserve is completely wiped out
     // staked lp tokens are slashed
@@ -1476,8 +1476,8 @@ describe("staking tests", () => {
     initiateUnstake(depositor1, 500n, 0);
 
     const withdrawal = getUserWithdrawal(depositor1, 0);
-    expect(withdrawal.data["withdrawal-shares"]).toEqual(Cl.uint(500));
-    expect(withdrawal.data["finalization-at"]).toEqual(
+    expect(withdrawal.value["withdrawal-shares"]).toEqual(Cl.uint(500));
+    expect(withdrawal.value["finalization-at"]).toEqual(
       Cl.uint(finalizationPeriod)
     );
 
@@ -1780,7 +1780,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    let totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    let totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3002n);
 
@@ -1790,7 +1790,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(115273775n)
     );
 
@@ -1800,7 +1800,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(
       1385n
     );
 
@@ -1814,7 +1814,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3002n);
 
@@ -1833,7 +1833,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(43227665n)
     );
 
@@ -1871,7 +1871,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // H-01 burn dust adds 1000 to every pool's total-assets baseline.
     expect(totalAssets).toEqual(3003n);
 
@@ -1897,7 +1897,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(796n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(796n);
 
     mint_token("mock-usdc", 100, deployer);
     const depositToReserve = simnet.callPublicFn(
@@ -1948,7 +1948,7 @@ describe("staking tests", () => {
       depositor1
     );
     expect(liquidate.result).toBeOk(Cl.bool(true));
-    let socializedDebt = liquidate.events[7].data.value.data["amount"].value;
+    let socializedDebt = liquidate.events[7].data.value.value["amount"].value;
 
     depositorBalance = simnet.callReadOnlyFn(
       "mock-usdc",
@@ -1972,7 +1972,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1), Cl.none(), Cl.none()],
       deployer
     );
-    expect(accounthealthRes.result.value.data["position-health"]).toEqual(
+    expect(accounthealthRes.result.value.value["position-health"]).toEqual(
       Cl.uint(100000000n)
     );
 
@@ -2014,7 +2014,7 @@ describe("staking tests", () => {
       [Cl.principal(borrower1)],
       borrower1
     );
-    expect(userDebtShares.result.value.data["debt-shares"].value).toEqual(0n);
+    expect(userDebtShares.result.value.value["debt-shares"].value).toEqual(0n);
 
     const reseverBalance = simnet.callReadOnlyFn(
       "state-v1",
@@ -2033,7 +2033,7 @@ describe("staking tests", () => {
       [],
       deployer
     );
-    totalAssets = totalAssetsRes.result.data["total-assets"].value;
+    totalAssets = totalAssetsRes.result.value["total-assets"].value;
     // this is after socializing the remaining debt from the user
     // total assets with interest is 2003 and reserve is completely wiped out
     // staked lp tokens are slashed

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -47,12 +47,12 @@ export const update_supported_collateral_governance = (
     governance_account
   );
   expect(response.result.type).toBe(ClarityType.ResponseOk);
-  const proposal_id = response.result.value.buffer;
+  const proposal_id = response.result.value.value;
   simnet.mineEmptyBlocks(21600);
   const res = simnet.callPublicFn(
     "governance-v1",
     "execute",
-    [Cl.buffer(proposal_id)],
+    [Cl.bufferFromHex(proposal_id)],
     governance_account
   );
   expect(res.result).toBeOk(Cl.bool(true));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": [
-    "node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src",
+    "node_modules/@stacks/clarinet-sdk/vitest-helpers/src",
     "tests"
   ]
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 import {
   vitestSetupFilePath,
   getClarinetVitestsArgv,
-} from "@hirosystems/clarinet-sdk/vitest";
+} from "@stacks/clarinet-sdk/vitest";
 
 /*
   In this file, Vitest is configured so that it works seamlessly with Clarinet and the Simnet.
@@ -22,6 +22,12 @@ import {
 */
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The pinned pyth submodule imports the pre-rename package name.
+      "@hirosystems/clarinet-sdk": "@stacks/clarinet-sdk",
+    },
+  },
   test: {
     include: ["./tests/**/*.test.ts"],
     environment: "clarinet", // use vitest-environment-clarinet


### PR DESCRIPTION
The Pyth Lazer work needs Clarity contracts at epoch 3.4, which the pinned clarinet-sdk 2.9 can't run. This bumps the test stack so vitest can run epoch-3.4 contracts and migrates the existing suite to the new APIs. No contract or test-behavior changes.

The SDK moved to @stacks/clarinet-sdk 3.21 (the @hirosystems scope is deprecated), which bundles clarinet-sdk-wasm 3.21 with epoch 3.4 support. Along with it: @stacks/transactions 6 to 7, vitest 1 to 3, and vitest-environment-clarinet 2 to 3. The vitest config and tsconfig point at the renamed package, and I aliased the old name so the pinned pyth submodule keeps resolving.

Stacks.js 7 unified clarity value access under .value: tuple .data, list .list, and buffer .buffer all become .value, buffer values are hex strings re-wrapped with Cl.bufferFromHex, and ClarityType is string-valued. The test edits are just those API updates, with every assertion unchanged. Full suite green at 21 files, 242 tests.
