### PR TITLE
add staging deployment plan v4

### DIFF
--- a/deployments/staging-plan-v4.yaml
+++ b/deployments/staging-plan-v4.yaml
@@ -1,0 +1,79 @@
+---
+id: 0
+name: Staging upgrade v4 - Pyth Lazer redeploy set (fresh deployer)
+network: mainnet
+stacks-node: "https://api.hiro.so"
+bitcoin-node: "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-publish:
+            contract-name: pyth-adapter-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            cost: 100000
+            path: contracts/modules/pyth-adapter-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: withdrawal-caps-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            cost: 100000
+            path: contracts/modules/withdrawal-caps-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: borrower-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            cost: 100000
+            path: contracts/borrower-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+      epoch: "3.4"
+    - id: 1
+      transactions:
+        - contract-publish:
+            contract-name: governance-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            cost: 100000
+            path: contracts/governance-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: liquidator-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            cost: 100000
+            path: contracts/liquidator-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: liquidity-provider-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            cost: 100000
+            path: contracts/liquidity-provider-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        - contract-publish:
+            contract-name: utility
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            cost: 100000
+            path: contracts/modules/utility.clar
+            anchor-block-only: true
+            clarity-version: 3
+      epoch: "3.4"
+    - id: 2
+      transactions:
+        - contract-call:
+            contract-id: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV.liquidity-provider-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            method: initialize
+            parameters: []
+            cost: 50000
+        - contract-call:
+            contract-id: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV.governance-v1
+            expected-sender: SPC626ZYQTCT5ZSDPNS9W1J172KPQ5V2NQX5K6DV
+            method: initialize-governance
+            parameters:
+              - "(list (some 'SPTXMEW26M54HX1ZXF6VN7QKK4XES1038ERD40T5) (some 'SP3ZPYKVNAQK52YDSQKEHZ3MZQ5MFFZ52E0TH7TJ1) (some 'SP3XD84X3PE79SHJAZCDW1V5E9EA8JSKRBPEKAEK7))"
+            cost: 50000
+      epoch: "3.4"


### PR DESCRIPTION
The deploy plan for the staging Pyth Lazer cutover: the seven upgradable contracts republished under a fresh deployer, plus the liquidity-provider and governance init calls.

This has already been applied on mainnet-staging and the market is running on it, so this is committing the plan as the record - same as we did for the previous staging upgrade. Plan only, no contract changes.
