### PR TITLE
seed pyth-adapter-v1 feeds and time-delta at deploy time

### DIFF
--- a/contracts/modules/pyth-adapter-v1.clar
+++ b/contracts/modules/pyth-adapter-v1.clar
@@ -11,6 +11,9 @@
 (define-constant ERR-INVALID-TIME-DELTA (err u80007))
 (define-constant ERR-MISSING-FEED (err u80008))
 (define-constant ERR-PRICE-LIST-OVERFLOW (err u80009))
+(define-constant ERR-CONTRACT-ALREADY-INITIALIZED (err u80010))
+(define-constant ERR-NOT-CONTRACT-DEPLOYER (err u80011))
+(define-constant ERR-EMPTY-FEED-LIST (err u80012))
 
 (define-constant STACKS_BLOCK_TIME (contract-call? .constants-v1 get-stacks-block-time ))
 ;; Minimum time delta of 15 seconds (~2 Stacks blocks). Prevents
@@ -35,6 +38,47 @@
   max-confidence-ratio: uint
 })
 (define-data-var time-delta uint u1800)
+
+;; contract deployer. No permissions except to initialize the contract
+(define-constant contract-deployer contract-caller)
+
+(define-data-var initialized bool false)
+
+;; A token repeated in `feeds` resolves last-one-wins.
+(define-public (initialize
+    (feeds (list 10 { token: principal, feed-id: uint, max-confidence-ratio: uint }))
+    (delta uint)
+  )
+  (begin
+    (asserts! (is-eq contract-caller contract-deployer) ERR-NOT-CONTRACT-DEPLOYER)
+    (asserts! (not (var-get initialized)) ERR-CONTRACT-ALREADY-INITIALIZED)
+    (asserts! (> (len feeds) u0) ERR-EMPTY-FEED-LIST)
+    (asserts! (is-eq (len (filter has-valid-confidence-ratio feeds)) (len feeds)) ERR-INVALID-MAX-CONFIDENCE-RATIO)
+    (asserts! (>= delta MINIMUM_TIME_DELTA) ERR-INVALID-TIME-DELTA)
+    (asserts! (<= delta MAXIMUM_TIME_DELTA) ERR-INVALID-TIME-DELTA)
+    (var-set initialized true)
+    (var-set time-delta delta)
+    (map seed-price-feed feeds)
+    (print {
+      event-type: "initialize",
+      user: contract-caller,
+      feeds: feeds,
+      time-delta: delta,
+    })
+    SUCCESS
+  )
+)
+
+(define-private (has-valid-confidence-ratio (entry { token: principal, feed-id: uint, max-confidence-ratio: uint }))
+  (<= (get max-confidence-ratio entry) CONFIDENCE_SCALING_FACTOR)
+)
+
+(define-private (seed-price-feed (entry { token: principal, feed-id: uint, max-confidence-ratio: uint }))
+  (map-set price-feeds (get token entry) {
+    feed-id: (get feed-id entry),
+    max-confidence-ratio: (get max-confidence-ratio entry),
+  })
+)
 
 ;; admin-level maintenance functions
 (define-public (update-price-feed-id (token principal) (new-feed-id uint) (max-confidence-ratio uint))

--- a/tests/modules/pyth-adapter.test.ts
+++ b/tests/modules/pyth-adapter.test.ts
@@ -13,10 +13,15 @@ import { buildEvmUpdate, buildLazerPayload, PROP, OTHER_PRIVKEY } from "../lazer
 
 const accounts = simnet.getAccounts();
 const deployer = accounts.get("deployer")!;
+const outsider = accounts.get("wallet_1")!;
 
 const btc = Cl.contractPrincipal(deployer, "mock-btc");
 const eth = Cl.contractPrincipal(deployer, "mock-eth");
 const usdc = Cl.contractPrincipal(deployer, "mock-usdc");
+
+const CONFIDENCE_SCALING_FACTOR = 10000;
+const MINIMUM_TIME_DELTA = 15;
+const MAXIMUM_TIME_DELTA = 7200;
 
 const register = (token: string) =>
   simnet.callPublicFn(
@@ -42,6 +47,18 @@ const verify = (tokens: any[], update?: Uint8Array) => {
     deployer
   ).result;
 };
+
+const feed = (token: string, ratio: number) =>
+  Cl.tuple({
+    token: Cl.contractPrincipal(deployer, token),
+    "feed-id": Cl.uint(get_token_feed_id(token)),
+    "max-confidence-ratio": Cl.uint(ratio),
+  });
+
+const initialize = (feeds: any[], delta: number, caller = deployer) =>
+  simnet.callPublicFn("pyth-adapter-v1", "initialize", [Cl.list(feeds), Cl.uint(delta)], caller).result;
+
+const time_delta = () => simnet.callReadOnlyFn("pyth-adapter-v1", "get-pyth-time-delta", [], deployer).result;
 
 // Build a single-feed blob with an explicit timestamp / signer for the timing + signature tests.
 const build_at = (feedId: number, price: bigint, expo: number, tsMicros: bigint, privKey?: Uint8Array) =>
@@ -164,5 +181,88 @@ describe("pyth-adapter-v1 time-delta bounds", () => {
 
   it("time-delta at maximum accepted", () => {
     expect(simnet.callPublicFn("pyth-adapter-v1", "update-time-delta", [Cl.uint(7200)], deployer).result).toBeOk(Cl.bool(true));
+  });
+});
+
+describe("pyth-adapter-v1 initialize", () => {
+  beforeEach(() => {
+    init_pyth(deployer);
+  });
+
+  it("seeds every feed and the time-delta in a single deployer call", () => {
+    expect(initialize([feed("mock-usdc", 100), feed("mock-btc", 500)], 300)).toBeOk(Cl.bool(true));
+    expect(time_delta()).toBeUint(300);
+
+    set_raw_feed("mock-usdc", 100000000n, -8);
+    set_raw_feed("mock-btc", 6000000000000n, -8);
+    expect(verify([usdc, btc])).toBeOk(
+      Cl.list([Cl.uint(converted_price("mock-usdc")), Cl.uint(converted_price("mock-btc"))])
+    );
+  });
+
+  it("cannot be initialized a second time", () => {
+    expect(initialize([feed("mock-usdc", 100)], 300)).toBeOk(Cl.bool(true));
+    expect(initialize([feed("mock-btc", 500)], 300)).toBeErr(Cl.uint(80010)); // ERR-CONTRACT-ALREADY-INITIALIZED
+  });
+
+  it("rejects a caller that is not the contract deployer", () => {
+    expect(initialize([feed("mock-usdc", 100)], 300, outsider)).toBeErr(Cl.uint(80011)); // ERR-NOT-CONTRACT-DEPLOYER
+  });
+
+  it("rejects an empty feed list", () => {
+    expect(initialize([], 300)).toBeErr(Cl.uint(80012)); // ERR-EMPTY-FEED-LIST
+  });
+
+  it("rejects the whole call for one bad max-confidence-ratio, seeding nothing", () => {
+    expect(initialize([feed("mock-usdc", 100), feed("mock-btc", CONFIDENCE_SCALING_FACTOR + 1)], 300)).toBeErr(
+      Cl.uint(80003) // ERR-INVALID-MAX-CONFIDENCE-RATIO
+    );
+
+    set_raw_feed("mock-usdc", 100000000n, -8);
+    expect(verify([usdc])).toBeErr(Cl.uint(80001)); // ERR-UNSUPPORTED-ASSET
+    expect(time_delta()).not.toBeUint(300);
+    // the one-shot was not burned by the rejected call
+    expect(initialize([feed("mock-usdc", 100)], 300)).toBeOk(Cl.bool(true));
+  });
+
+  it("accepts a max-confidence-ratio at the scaling factor", () => {
+    expect(initialize([feed("mock-usdc", CONFIDENCE_SCALING_FACTOR)], 300)).toBeOk(Cl.bool(true));
+  });
+
+  it("rejects a time-delta below the minimum", () => {
+    expect(initialize([feed("mock-usdc", 100)], MINIMUM_TIME_DELTA - 1)).toBeErr(Cl.uint(80007)); // ERR-INVALID-TIME-DELTA
+  });
+
+  it("rejects a time-delta above the maximum", () => {
+    expect(initialize([feed("mock-usdc", 100)], MAXIMUM_TIME_DELTA + 1)).toBeErr(Cl.uint(80007));
+  });
+
+  it("accepts a time-delta at the minimum", () => {
+    expect(initialize([feed("mock-usdc", 100)], MINIMUM_TIME_DELTA)).toBeOk(Cl.bool(true));
+    expect(time_delta()).toBeUint(MINIMUM_TIME_DELTA);
+  });
+
+  it("accepts a time-delta at the maximum", () => {
+    expect(initialize([feed("mock-usdc", 100)], MAXIMUM_TIME_DELTA)).toBeOk(Cl.bool(true));
+    expect(time_delta()).toBeUint(MAXIMUM_TIME_DELTA);
+  });
+
+  it("leaves the governance rotation path working", () => {
+    expect(initialize([feed("mock-usdc", 100), feed("mock-btc", 500)], 300)).toBeOk(Cl.bool(true));
+    expect(register("mock-eth").result).toBeOk(Cl.bool(true));
+
+    set_raw_feed("mock-eth", 300000000000n, -8);
+    expect(verify([eth])).toBeOk(Cl.list([Cl.uint(converted_price("mock-eth"))]));
+  });
+
+  it("still rejects update-price-feed-id from a non-governance principal", () => {
+    expect(initialize([feed("mock-usdc", 100)], 300)).toBeOk(Cl.bool(true));
+    const res = simnet.callPublicFn(
+      "pyth-adapter-v1",
+      "update-price-feed-id",
+      [eth, Cl.uint(get_token_feed_id("mock-eth")), Cl.uint(500)],
+      outsider
+    );
+    expect(res.result).toBeErr(Cl.uint(80000)); // ERR-NOT-AUTHORIZED
   });
 });

--- a/tests/modules/pyth-adapter.test.ts
+++ b/tests/modules/pyth-adapter.test.ts
@@ -220,7 +220,7 @@ describe("pyth-adapter-v1 initialize", () => {
 
     set_raw_feed("mock-usdc", 100000000n, -8);
     expect(verify([usdc])).toBeErr(Cl.uint(80001)); // ERR-UNSUPPORTED-ASSET
-    expect(time_delta()).not.toBeUint(300);
+    expect(time_delta()).toBeUint(1800); // the contract default, untouched by the rejected call
     // the one-shot was not burned by the rejected call
     expect(initialize([feed("mock-usdc", 100)], 300)).toBeOk(Cl.bool(true));
   });


### PR DESCRIPTION
The only way to write a Lazer feed-id into the adapter today is `update-price-feed-id`, which gates on governance. At deploy time the caller is the deployer EOA, so a fresh adapter can't be seeded during its own deploy plan and the feeds have to be set afterwards through governance proposals. That was cheap on staging; on mainnet it's a multi-day 3-of-4 round trip before the market can do anything.

I've added a one-shot `initialize`, callable only by the contract deployer, that takes the feed list and the time-delta together. It validates every entry and the delta before writing anything, so one bad entry fails the whole call and leaves the adapter unseeded and still initializable. An empty list is rejected too, otherwise a stray empty call would burn the one-shot and leave the adapter permanently unusable. `update-price-feed-id` and `update-time-delta` are unchanged; they're still the rotation path after deploy.
