### PR TITLE
bump CI clarinet pin to 3.21.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
           submodules: true
       - name: "Install Clarinet"
         run: |
-          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.18.1/clarinet-linux-x64-glibc.tar.gz | tar -xz
+          curl -L https://github.com/hirosystems/clarinet/releases/download/v3.21.1/clarinet-linux-x64-glibc.tar.gz | tar -xz
           chmod +x ./clarinet
           echo "$PWD" >> "$GITHUB_PATH"
       - name: "Check contract syntax"


### PR DESCRIPTION
CI pins clarinet 3.18.1, but `deployments/default.simnet-plan.yaml` was generated by a newer one: running `clarinet check` under 3.18.1 rewrites the file to drop `costs-5` and `pox-5` from the genesis boot list. CI never notices because it only runs the check and never diffs the result, so the churn lands on whoever ran it locally. Under 3.21.1 the check leaves the plan completely untouched, and the repo's own `@stacks/clarinet-sdk` dependency is already 3.21.1, so that's where the committed artifact came from.

This bumps the CI pin to match. If you work on this repo you'll want clarinet 3.21.1 locally now - on 3.18.1 you'll be the one reintroducing that diff every time you run a check.

One side effect worth flagging: 3.21.1 adds a `flatten_variadic` lint that 3.18.1 didn't have, so the warning count goes from 86 to 90. All four are `(+ (+ a b) c)` in existing code, nothing new and nothing broken, and I left them alone rather than reformatting unrelated contracts. No errors either way, and the test suite is unchanged at 275.
