### PR TITLE
upload the coverage report CI actually produces, and finish the devDependencies split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,3 @@ jobs:
         run: npm ci
       - name: "Execute unit tests"
         run: npm run test:report
-      - name: "Upload code coverage"
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./coverage.lcov
-          verbose: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,12 @@
       "name": "granite-core",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.5.0",
-        "@noble/secp256k1": "^2.1.0",
-        "@stacks/transactions": "7.4.0"
-      },
       "devDependencies": {
         "@fast-check/vitest": "^0.3.0",
+        "@noble/hashes": "^1.5.0",
+        "@noble/secp256k1": "^2.1.0",
         "@stacks/clarinet-sdk": "^3.22.0",
+        "@stacks/transactions": "7.4.0",
         "chokidar-cli": "^3.0.0",
         "fast-check": "^3.22.0",
         "typescript": "^5.6.2",
@@ -503,6 +501,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -514,6 +513,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-2.1.0.tgz",
       "integrity": "sha512-XLEQQNdablO0XZOIniFQimiXsZDNwaYgL96dZwC54Q30imSbAOFf3NKtepc+cXyuZf5Q1HCgbqgZ2UFFuHVcEw==",
+      "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -934,12 +934,14 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.5.0.tgz",
       "integrity": "sha512-UkKM3J7VufGEEuHLYRAFZQFbiQeACMpMMzGbBL6qo/6YLXvPPXA8MBffeCsXE65/a0bJSbh+0Q7rfdio9IvZ1w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stacks/network": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.5.0.tgz",
       "integrity": "sha512-FKfw864+ipj0RBa0kXBCKp+6Bm/8IS1pk+jg5NJhi//NzG8fZsC4MsER1F8qvzVoFrLfZjqxo+3sJDYfvHbVOQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stacks/common": "^7.5.0",
@@ -950,6 +952,7 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.4.0.tgz",
       "integrity": "sha512-scsQO3rSNNKcPHp56Wy5OeZiIpQNmmZOORz8bkQKWjzvzycAodtSWmAoHiMFAKSleR1NyeRIz642fReqlZU9tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.1.5",
@@ -964,6 +967,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
       "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -975,6 +979,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
       "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1174,7 +1179,8 @@
     "node_modules/base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1204,6 +1210,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
       "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "^1.1.2",
         "base-x": "^4.0.0"
@@ -1455,6 +1462,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
       "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
@@ -1757,7 +1765,8 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -1818,6 +1827,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -2249,6 +2259,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -2494,12 +2505,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,12 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "@noble/hashes": "^1.5.0",
-    "@noble/secp256k1": "^2.1.0",
-    "@stacks/transactions": "7.4.0"
-  },
   "devDependencies": {
     "@fast-check/vitest": "^0.3.0",
+    "@noble/hashes": "^1.5.0",
+    "@noble/secp256k1": "^2.1.0",
     "@stacks/clarinet-sdk": "^3.22.0",
+    "@stacks/transactions": "7.4.0",
     "chokidar-cli": "^3.0.0",
     "fast-check": "^3.22.0",
     "typescript": "^5.6.2",


### PR DESCRIPTION
The coverage upload never worked, and it could not have. CI pointed codecov at `./coverage.lcov`, but the clarinet SDK writes its report to `lcov.info` - that is the SDK's default filename, and `.gitignore` has been carrying `*.info` all along. With no `fail_ci_if_error` the step passed on a file that was not there, every run.

I fixed the filename first and codecov did then find the report, so that part was only ever a typo. The upload still failed: codecov returns `400 Token required - not valid tokenless upload` for this repo, so it needs a `CODECOV_TOKEN` secret regardless of which file we point it at. That makes it a maintenance decision rather than a fix, so I have dropped the step instead of leaving a check that green-lights on nothing.

Coverage itself is untouched - `npm run test:report` still writes `lcov.info` and `costs-reports.json` locally, and CI still runs it. If we want the upload back it is a small change: add the repo secret and re-add the step with the token wired in. Happy to do that instead if coverage on the dashboard is worth maintaining.

The second commit finishes the dependency split. @noble/hashes, @noble/secp256k1 and @stacks/transactions are only imported from `tests/` - the one other JS file in the repo is `vitest.config.js`, which pulls from the clarinet SDK - so they belong with the rest of the test tooling. `dependencies` is empty now and gone from the manifest, which is what you would expect from a Clarity repo that ships no JavaScript.
