### PR TITLE
add the USDCx Lazer deployment plan

### DIFF
--- a/deployments/mainnet-usdcx-plan-v2.yaml
+++ b/deployments/mainnet-usdcx-plan-v2.yaml
@@ -1,0 +1,159 @@
+---
+id: 0
+name: USDCx Pyth Lazer cutover v2 - Lazer redeploy set (fresh deployer)
+network: mainnet
+stacks-node: "https://api.hiro.so"
+bitcoin-node: "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332"
+#
+# HARD PRECONDITION: do NOT apply before burn height 960230.
+# Epoch40 activates at burn 960230. At the time this plan was written the chain was at burn
+# 960106, still inside Epoch34 [943333, 960230). Applying earlier fails outright rather than
+# costing money, but re-verify the active epoch against the burn tip before applying.
+#
+# Anchor: SP3M2BYF7RGF8WKW5FVDNJ6WR8D7AR9BHDXAKPXZE. state-v1, math-v1, constants-v1,
+# constants-v2, staking-reward-v1, trait-flash-loan-v1 and meta-governance-v1 all stay live at the
+# anchor and are referenced fully-qualified. meta-governance-v1 is deliberately REUSED: its
+# 4-member set is untouched by this deploy.
+#
+# Publish order is derived from the hard-dependency graph, not copied from staging. A
+# (contract-call? .peer ...) needs the peer to exist at publish time; an (as-contract .peer) is
+# only a principal literal and does not. That is why withdrawal-caps-v1 publishes in batch 0
+# ahead of the borrower/liquidator/liquidity-provider trio it names via as-contract.
+# Batch 0 holds every contract with no intra-set hard dependency except staking-v1, which needs
+# linear-kinked-ir-v1 and is ordered after it. That is the only same-batch dependency and it is
+# safe: Stacks enforces per-account nonce ordering, so the later publish cannot be applied before
+# the earlier one even inside a single block. Staging's cutover relied on the same property.
+# Every batch-1 contract depends only on batch-0 contracts, so batch 1 has no internal constraint.
+#
+# `cost` is the tx fee in uSTX and is what `-d` uses, so it is deliberately generous: an
+# under-funded fee can strand the deploy mid-batch. Two reference points, both proven on mainnet:
+# the committed Lazer plan paid 100000 for contracts up to ~16KB and 200000 at ~20KB, and
+# staging's live-validated cutover published a 53KB governance-v1 at a flat 100000. Fees here are
+# therefore not strictly size-driven; the figures below apply max(100000, ceil(KB/10)*100000) as
+# headroom over the proven-flat rate. Publishes total 2100000 and the batch-2 calls 250000, so
+# 2350000 uSTX (2.35 STX) versus 1150000 (1.15 STX) at the proven-flat rate. Fund ~3 STX.
+#
+# No USDCx is needed. liquidity-provider-v1.initialize only flips its gate flag: live LP supply is
+# u4997790831428, so dust-burned is false and it takes the no-deposit branch.
+#
+# staking-v1.initialize is deliberately NOT in this plan. It is deployer-gated and stakes the
+# dead-shares floor, so it needs staking authorized plus the deployer holding MINIMUM_INITIAL_STAKE
+# of the LP token; run it after the authorize wave. Total staked is u0 today, so deferring costs
+# nothing.
+plan:
+  batches:
+    - id: 0
+      transactions:
+        # 8.1KB - no intra-set hard dependency
+        - contract-publish:
+            contract-name: linear-kinked-ir-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 100000
+            path: contracts/modules/linear-kinked-ir-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 15.5KB - hard-needs linear-kinked-ir-v1, so it follows it in this batch
+        - contract-publish:
+            contract-name: staking-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 200000
+            path: contracts/staking-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 3.5KB
+        - contract-publish:
+            contract-name: flash-loan-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 100000
+            path: contracts/flash-loan-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 10.3KB
+        - contract-publish:
+            contract-name: pyth-adapter-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 200000
+            path: contracts/modules/pyth-adapter-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 11.5KB - names borrower/liquidator/liquidity-provider only via as-contract
+        - contract-publish:
+            contract-name: withdrawal-caps-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 200000
+            path: contracts/modules/withdrawal-caps-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+      epoch: "4.0"
+    - id: 1
+      transactions:
+        # 17.8KB
+        - contract-publish:
+            contract-name: borrower-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 200000
+            path: contracts/borrower-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 53.6KB
+        - contract-publish:
+            contract-name: governance-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 600000
+            path: contracts/governance-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 29.3KB
+        - contract-publish:
+            contract-name: liquidator-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 300000
+            path: contracts/liquidator-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 4.8KB
+        - contract-publish:
+            contract-name: liquidity-provider-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 100000
+            path: contracts/liquidity-provider-v1.clar
+            anchor-block-only: true
+            clarity-version: 3
+        # 7.5KB
+        - contract-publish:
+            contract-name: utility
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            cost: 100000
+            path: contracts/modules/utility.clar
+            anchor-block-only: true
+            clarity-version: 3
+      epoch: "4.0"
+    - id: 2
+      transactions:
+        # Flips the flag gating deposit/withdraw. Takes the no-deposit branch, see the note above.
+        - contract-call:
+            contract-id: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT.liquidity-provider-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            method: initialize
+            parameters: []
+            cost: 50000
+        # Lazer numeric feed ids and confidence ratios, read live off the chain: USDC/USD u7 at
+        # u100 and BTC/USD u1 at u500, freshness delta u300 (live value; min u15, max u7200).
+        - contract-call:
+            contract-id: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT.pyth-adapter-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            method: initialize
+            parameters:
+              - "(list { token: 'SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx, feed-id: u7, max-confidence-ratio: u100 } { token: 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token, feed-id: u1, max-confidence-ratio: u500 })"
+              - "u300"
+            cost: 100000
+        # All SIX live guardians. The signature is (list 6 (optional principal)) in this deploy
+        # source; master's (list 5 ...) would fail here, after every publish above has been paid for.
+        - contract-call:
+            contract-id: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT.governance-v1
+            expected-sender: SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT
+            method: initialize-governance
+            parameters:
+              - "(list (some 'SP1ABZHX4VKG0BTQ8NTBJ591W7AK67C33KR76QD27) (some 'SPTXMEW26M54HX1ZXF6VN7QKK4XES1038ERD40T5) (some 'SP2G62YGCCMWS4PAN54ZYT2G9TCJRGBSKQ679M96Q) (some 'SP2EBZVFF99Q97GJXGTRT3Y0M7N6G7XJAKMNVGFK) (some 'SP298TX7MBC848DGTXYP0594AGSHJAKBFZE3VH1E9) (some 'SP2A7DWZMPQAQC0W941VA8RYJNX56A2WJ0GP1RS3E))"
+            cost: 100000
+      epoch: "4.0"


### PR DESCRIPTION
Adds the deployment plan we actually applied for the USDCx Pyth Lazer cutover, so the repo stops
misrepresenting what is live. All ten contracts published under `SPSX722NK9V3A8D3CVQT0CDY4EBQ3E9FSDDE61FT`
and the plan here matches the chain exactly - I checked the contract set against the deployer's
transaction history rather than against my notes.

Plan only. The deploy source it was applied from stays on its own branch and is not for merging.

The comments are worth keeping rather than trimming: the publish ordering is derived from the
hard-dependency graph rather than copied from staging, and the per-contract costs are deliberately
generous because an under-funded fee strands a deploy mid-batch instead of failing cleanly.
