### PR TITLE
Trim the Pyth Lazer oracle deployment plan to the plan itself

### DIFF
--- a/deployments/pyth-lazer-plan-v1.yaml
+++ b/deployments/pyth-lazer-plan-v1.yaml
@@ -4,11 +4,7 @@ name: Pyth Lazer oracle deploy v1 - self-owned verify-only stack (dedicated depl
 network: mainnet
 stacks-node: "https://api.hiro.so"
 bitcoin-node: "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332"
-# Canonical mainnet Pyth Lazer oracle, shared by staging + USDCx + aeUSDC.
-# Deployer: SPMV5HDZ4EMB8XY7HAYT3XW0DF7DZ4E8XEG2J1T8 (settings/Mainnet.toml -> accounts.pyth-lazer-deployer).
-# `cost` = fixed fee in µSTX, matching the proven 100000 (0.1 STX)/publish the USDCx deploy paid and
-# confirmed on mainnet; decoder bumped to 200000 for its size (~20 KB). Ignore clarinet's
-# --medium/--low-cost estimator here (it wildly overestimates: 2.5 / 0.7 STX/publish).
+# Applied on mainnet 2026-07-22 - all 4 transactions succeeded.
 plan:
   batches:
     - id: 0
@@ -37,9 +33,6 @@ plan:
       epoch: "3.4"
     - id: 1
       transactions:
-        # Seed Pyth's production Lazer signer (confirmed live 2026-07-22). Deployer holds
-        # ROLE_GOVERNANCE at publish and set-trusted-signers is exempt from the pause gate, so this
-        # passes directly. expires-at u1924992000 = 2031-01-01 UTC (backstop; rotate via governance).
         - contract-call:
             contract-id: SPMV5HDZ4EMB8XY7HAYT3XW0DF7DZ4E8XEG2J1T8.pyth-lazer-oracle
             expected-sender: SPMV5HDZ4EMB8XY7HAYT3XW0DF7DZ4E8XEG2J1T8


### PR DESCRIPTION
Trims the Pyth Lazer oracle plan down to the plan itself, so every deployment plan in the repo is now a bare data file with at most a one-line header.

Unlike the two cutover plans, this one's comments were operational rather than retrospective, so I moved what was worth keeping somewhere it will actually be re-read before dropping it. The parsed YAML is unchanged - I diffed it before and after and the whole document is deep-equal, signer parameters included.
